### PR TITLE
Sentry Release Integration & Workflow updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,16 +4,11 @@ concurrency: production
 on:
   push:
     branches: [master]
-  workflow_run:
-    workflows: [Sith3 CI]
-    types: [completed]
   workflow_dispatch:
 
 jobs:
-  # Runs only if Unit tests are successful
   deployment:
     runs-on: ubuntu-latest
-    if: ${{github.event.workflow_run.conclusion == 'success'}}
     environment: production
     timeout-minutes: 30
   
@@ -41,7 +36,6 @@ jobs:
           export PATH="$HOME/.poetry/bin:$PATH"
           pushd ${{secrets.SITH_PATH}}
 
-          VERSION_LAST=$(git rev-parse HEAD)
           git pull
           poetry update
           poetry run ./manage.py migrate
@@ -50,3 +44,15 @@ jobs:
           poetry run ./manage.py compilemessages
 
           sudo systemctl restart uwsgi
+
+  sentry-release:
+    - uses: actions/checkout@v2
+    - name: Create Sentry release
+      uses: getsentry/action-release@v1
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        SENTRY_URL: ${{ secrets.SENTRY_URL }}
+      with:
+        environment: production

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -3,6 +3,8 @@ name: Sith3 CI
 on:
   pull_request:
     branches: [ master ]
+  push:
+    branches: [ master ]
     
 jobs:
   unittests:


### PR DESCRIPTION
Each time a commit is merged into master, this create a new release on Sentry (using [Sentry Release Action](https://github.com/marketplace/actions/sentry-release))

Also, `deployment` action is now only triggered on push to master, whereas before this action was triggered right after the `unit testing` action. This led to issues where deployment was triggered after unit testing for pull requests.