### PR TITLE
Selected club members can now see subscriptions

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -415,6 +415,17 @@ class User(AbstractBaseUser):
         )
 
     @cached_property
+    def can_read_subscription(self):
+        from club.models import Club
+
+        for club in Club.objects.filter(
+            id__in=settings.SITH_CAN_READ_SUBSCRIPTIONS
+        ).all():
+            if club.has_rights_in_club(self):
+                return True
+        return False
+
+    @cached_property
     def can_create_subscription(self):
         from club.models import Club
 
@@ -689,6 +700,10 @@ class AnonymousUser(AuthAnonymousUser):
 
     @property
     def can_create_subscription(self):
+        return False
+
+    @property
+    def can_read_subscription(self):
         return False
 
     @property

--- a/core/templates/core/user_detail.jinja
+++ b/core/templates/core/user_detail.jinja
@@ -145,7 +145,7 @@
         {% endif %}
         </div>
     {% endif %}
-    {% if profile.was_subscribed and (user == profile or user.is_root or user.is_board_member)%}
+    {% if profile.was_subscribed and (user == profile or user.is_root or user.is_board_member or user.can_read_subscription)%}
         <div id="drop_subscriptions">
             <h5>{% trans %}Subscription history{% endtrans %}</h5>
             <table>

--- a/sith/settings.py
+++ b/sith/settings.py
@@ -474,6 +474,8 @@ SITH_PRODUCTTYPE_SUBSCRIPTION = 2
 
 SITH_CAN_CREATE_SUBSCRIPTIONS = [1]
 
+SITH_CAN_READ_SUBSCRIPTIONS = [85]
+
 # Number of weeks before the end of a subscription when the subscriber can resubscribe
 SITH_SUBSCRIPTION_END = 10
 


### PR DESCRIPTION
Needed for the case of the integration week, by editing `settings.py` or `settings_custom.py` and adding the club `id` to the list.