### PR TITLE
Switched Calendar link to Elections list link (as it was unused)

### DIFF
--- a/core/templates/core/base.jinja
+++ b/core/templates/core/base.jinja
@@ -179,7 +179,7 @@
                 <i class="fa fa-caret-down"></i>
                 </button>
                 <div class="dropdown-content">
-                    <a href="{{ url('core:page', page_name='Index/calendrier_evenements') }}">{% trans %}Calendar{% endtrans %}</a>
+                    <a href="{{ url('election:list') }}">{% trans %}Elections{% endtrans %}</a>
                     <a href="{{ url('core:page', page_name='ga') }}">{% trans %}Big event{% endtrans %}</a>
                 </div>
               </div>


### PR DESCRIPTION
Easy as that aha

> I've taken the time to delete the associated forum page on the production site