### PR TITLE
Correct wrong et_autoanswer url

### DIFF
--- a/eboutic/templates/eboutic/eboutic_makecommand.jinja
+++ b/eboutic/templates/eboutic/eboutic_makecommand.jinja
@@ -42,16 +42,16 @@
             {% endif %}
         {% endif %}
     </p>
-{#    {% if settings.SITH_EBOUTIC_CB_ENABLED %}#}
-{#    <form method="post" action="{{ settings.SITH_EBOUTIC_ET_URL }}">#}
-{#        <p>#}
-{#        {% for (field_name,field_value) in et_request.items() -%}#}
-{#        <input type="hidden" name="{{ field_name }}" value="{{ field_value }}">#}
-{#        {% endfor %}#}
-{#        <input type="submit" value="{% trans %}Pay with credit card{% endtrans %}" />#}
-{#        </p>#}
-{#    </form>#}
-{#    {% endif %}#}
+    {% if settings.SITH_EBOUTIC_CB_ENABLED %}
+    <form method="post" action="{{ settings.SITH_EBOUTIC_ET_URL }}">
+        <p>
+        {% for (field_name,field_value) in et_request.items() -%}
+        <input type="hidden" name="{{ field_name }}" value="{{ field_value }}">
+        {% endfor %}
+        <input type="submit" value="{% trans %}Pay with credit card{% endtrans %}" />
+        </p>
+    </form>
+    {% endif %}
     {% if basket.contains_refilling_item %}
     <p>{% trans %}AE account payment disabled because your basket contains refilling items.{% endtrans %}</p>
     {% else %}

--- a/eboutic/urls.py
+++ b/eboutic/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     path("pay/", pay_with_sith, name="pay_with_sith"),
     path("pay/<res:result>/", payment_result, name="payment_result"),
     path(
-        "et_autoanswer/",
+        "et_autoanswer",
         EtransactionAutoAnswer.as_view(),
         name="etransation_autoanswer",
     ),


### PR DESCRIPTION
J'ai trouvé l'erreur. En fait c'était tout con. Il y avait un slash en trop à la fin de l'url pour la réponse de la banque. Les paiements étaient valides, en fait. Juste on recevait pas la réponse.