### PR TITLE
Eboutic 3DSv2 patch

### DIFF
--- a/counter/models.py
+++ b/counter/models.py
@@ -175,13 +175,13 @@ class BillingInfo(models.Model):
                 "Address1": self.address_1,
                 "ZipCode": self.zip_code,
                 "City": self.city,
-                "CountryCode": self.country,
+                "CountryCode": self.country.numeric,  # ISO-3166-1 numeric code
             }
         }
         if self.address_2:
             data["Address"]["Address2"] = self.address_2
         xml = dict2xml(data, wrap="Billing", newlines=False)
-        return '<?xml version="1.0" encoding="UTF-8" ?>' + xml
+        return '<?xml version="1.0" encoding="UTF-8" ?>\n' + xml
 
     def __str__(self):
         return f"{self.first_name} {self.last_name}"


### PR DESCRIPTION
En cherchant pourquoi la banque pouvait bloquer la requête, je me suis rendu compte que c'est le code alphabétique et pas le code numérique qui était mis dans la requête.

Comme la librairie django_countries est bien foutue, ça a été simple à corriger.

J'espère que c'est la dernière modification avant que la banque accepte les requêtes 3DSecure v2 du site.