### PR TITLE
Changement du comportement de Poetry dans les workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           pushd ${{secrets.SITH_PATH}}
 
           git pull
-          poetry update
+          poetry install
           poetry run ./manage.py migrate
           echo "yes" | poetry run ./manage.py collectstatic
           poetry run ./manage.py compilestatic

--- a/.github/workflows/taiste.yml
+++ b/.github/workflows/taiste.yml
@@ -35,7 +35,7 @@ jobs:
           pushd ${{secrets.SITH_PATH}}
 
           git pull
-          poetry update
+          poetry install
           poetry run ./manage.py migrate
           echo "yes" | poetry run ./manage.py collectstatic
           poetry run ./manage.py compilestatic


### PR DESCRIPTION
Résoud le soucis lié à dependabot.

Le problème venait du fait que l'on faisait un `poetry update` et non un `poetry Install`.  Un update écrit dans `poetry.lock`, alors qu'un Install lit ce fichier. C'est là toute la différence. 

Cette PR change donc les workflows.

Laisser ce bot apporte beaucoup de sécurité, vu qu'il nous prévient des changement, et aussi des vulnérabilités au niveau des dépendances. 