### PR TITLE
redirect the user directly on counter if user is barman

### DIFF
--- a/core/templates/core/base.jinja
+++ b/core/templates/core/base.jinja
@@ -65,20 +65,26 @@
             <div id="header_bar">
                 <ul id="header_bars_infos">
                 {% cache 100 "counters_activity" %}
-                  {% for bar in Counter.objects.filter(type="BAR").all() %}
-                      <li>
-                      <a href="{{ url('counter:activity', counter_id=bar.id) }}" style="padding: 0px">
-                      {% if bar.is_inactive(): %}
-                          <i class="fa fa-question" style="color: #f39c12"></i>
-                      {% elif bar.is_open(): %}
-                          <i class="fa fa-check" style="color: #2ecc71"></i>
-                      {% else %}
-                          <i class="fa fa-times" style="color: #eb2f06"></i>
-                      {% endif %}
-                          {{ bar }}
-                      </a>
-                      </li>
-                  {% endfor %}
+                    {% for bar in Counter.objects.annotate_has_barman(user).filter(type="BAR") %}
+                        <li>
+                            {# If the user is a barman, we redirect him directly to the barman page
+                            else we redirect him to the activity page #}
+                            {% if bar.has_annotated_barman %}
+                                <a href="{{ url('counter:details', counter_id=bar.id) }}" style="padding: 0">
+                            {% else %}
+                                <a href="{{ url('counter:activity', counter_id=bar.id) }}" style="padding: 0">
+                            {% endif %}
+                                {% if bar.is_inactive(): %}
+                                  <i class="fa fa-question" style="color: #f39c12"></i>
+                                {% elif bar.is_open(): %}
+                                  <i class="fa fa-check" style="color: #2ecc71"></i>
+                                {% else %}
+                                  <i class="fa fa-times" style="color: #eb2f06"></i>
+                                {% endif %}
+                                {{ bar }}
+                            </a>
+                        </li>
+                    {% endfor %}
                   </ul>
                 {% endcache %}
                 <form action="{{ url('core:search') }}" method="GET" id="header_search">

--- a/counter/tests.py
+++ b/counter/tests.py
@@ -138,6 +138,20 @@ class CounterTest(TestCase):
         )
         self.assertTrue(response.status_code == 200)
 
+    def test_annotate_has_barman_queryset(self):
+        """
+        Test if the custom queryset method ``annotate_has_barman``
+        works as intended
+        """
+        self.sli.counters.clear()
+        self.sli.counters.add(self.foyer, self.mde)
+        counters = Counter.objects.annotate_has_barman(self.sli)
+        for counter in counters:
+            if counter.name in ("Foyer", "MDE"):
+                self.assertTrue(counter.has_annotated_barman)
+            else:
+                self.assertFalse(counter.has_annotated_barman)
+
 
 class CounterStatsTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
C'est très chiant de devoir modifier manuellement son URL pour arriver sur la page du comptoir, particulièrement sur téléphone (et justement, les comptoirs sont beaucoup utilisés sur tel).

Donc ici, on fait en sorte que quand on clique sur un comptoir dans le bandeau supérieur, on redirige l'utilisateur :
- s'il est barman du comptoir en question : vers la page du comptoir (sans qu'il ait à modifier manuellement l'URL)
- sinon, vers la page d'activité du comptoir (comme avant)

Pour faire ça sans rajouter de requêtes supplémentaire, j'ai modifié le Manager par défaut du modèle `Counter` afin de lui rajouter la méthode `annotate_user_is_barman(user)`, qui permet d'annoter le queryset avec un booléen qui vaut True quand l'utilisateur fait partie des vendeurs du comptoir en question, sinon False.