### PR TITLE
upgrade re_path to path

### DIFF
--- a/accounting/urls.py
+++ b/accounting/urls.py
@@ -22,133 +22,127 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from accounting.views import *
 
 urlpatterns = [
     # Accounting types
-    re_path(
-        r"^simple_type$",
+    path(
+        "simple_type/",
         SimplifiedAccountingTypeListView.as_view(),
         name="simple_type_list",
     ),
-    re_path(
-        r"^simple_type/create$",
+    path(
+        "simple_type/create/",
         SimplifiedAccountingTypeCreateView.as_view(),
         name="simple_type_new",
     ),
-    re_path(
-        r"^simple_type/(?P<type_id>[0-9]+)/edit$",
+    path(
+        "simple_type/<int:type_id>/edit/",
         SimplifiedAccountingTypeEditView.as_view(),
         name="simple_type_edit",
     ),
     # Accounting types
-    re_path(r"^type$", AccountingTypeListView.as_view(), name="type_list"),
-    re_path(r"^type/create$", AccountingTypeCreateView.as_view(), name="type_new"),
-    re_path(
-        r"^type/(?P<type_id>[0-9]+)/edit$",
+    path("type/", AccountingTypeListView.as_view(), name="type_list"),
+    path("type/create/", AccountingTypeCreateView.as_view(), name="type_new"),
+    path(
+        "type/<int:type_id>/edit/",
         AccountingTypeEditView.as_view(),
         name="type_edit",
     ),
     # Bank accounts
-    re_path(r"^$", BankAccountListView.as_view(), name="bank_list"),
-    re_path(r"^bank/create$", BankAccountCreateView.as_view(), name="bank_new"),
-    re_path(
-        r"^bank/(?P<b_account_id>[0-9]+)$",
+    path("", BankAccountListView.as_view(), name="bank_list"),
+    path("bank/create", BankAccountCreateView.as_view(), name="bank_new"),
+    path(
+        "bank/<int:b_account_id>/",
         BankAccountDetailView.as_view(),
         name="bank_details",
     ),
-    re_path(
-        r"^bank/(?P<b_account_id>[0-9]+)/edit$",
+    path(
+        "bank/<int:b_account_id>/edit/",
         BankAccountEditView.as_view(),
         name="bank_edit",
     ),
-    re_path(
-        r"^bank/(?P<b_account_id>[0-9]+)/delete$",
+    path(
+        "bank/<int:b_account_id>/delete/",
         BankAccountDeleteView.as_view(),
         name="bank_delete",
     ),
     # Club accounts
-    re_path(r"^club/create$", ClubAccountCreateView.as_view(), name="club_new"),
-    re_path(
-        r"^club/(?P<c_account_id>[0-9]+)$",
+    path("club/create/", ClubAccountCreateView.as_view(), name="club_new"),
+    path(
+        "club/<int:c_account_id>/",
         ClubAccountDetailView.as_view(),
         name="club_details",
     ),
-    re_path(
-        r"^club/(?P<c_account_id>[0-9]+)/edit$",
+    path(
+        "club/<int:c_account_id>/edit/",
         ClubAccountEditView.as_view(),
         name="club_edit",
     ),
-    re_path(
-        r"^club/(?P<c_account_id>[0-9]+)/delete$",
+    path(
+        "club/<int:c_account_id>/delete/",
         ClubAccountDeleteView.as_view(),
         name="club_delete",
     ),
     # Journals
-    re_path(r"^journal/create$", JournalCreateView.as_view(), name="journal_new"),
-    re_path(
-        r"^journal/(?P<j_id>[0-9]+)$",
+    path("journal/create/", JournalCreateView.as_view(), name="journal_new"),
+    path(
+        "journal/<int:j_id>/",
         JournalDetailView.as_view(),
         name="journal_details",
     ),
-    re_path(
-        r"^journal/(?P<j_id>[0-9]+)/edit$",
+    path(
+        "journal/<int:j_id>/edit/",
         JournalEditView.as_view(),
         name="journal_edit",
     ),
-    re_path(
-        r"^journal/(?P<j_id>[0-9]+)/delete$",
+    path(
+        "journal/<int:j_id>/delete/",
         JournalDeleteView.as_view(),
         name="journal_delete",
     ),
-    re_path(
-        r"^journal/(?P<j_id>[0-9]+)/statement/nature$",
+    path(
+        "journal/<int:j_id>/statement/nature/",
         JournalNatureStatementView.as_view(),
         name="journal_nature_statement",
     ),
-    re_path(
-        r"^journal/(?P<j_id>[0-9]+)/statement/person$",
+    path(
+        "journal/<int:j_id>/statement/person/",
         JournalPersonStatementView.as_view(),
         name="journal_person_statement",
     ),
-    re_path(
-        r"^journal/(?P<j_id>[0-9]+)/statement/accounting$",
+    path(
+        "journal/<int:j_id>/statement/accounting/",
         JournalAccountingStatementView.as_view(),
         name="journal_accounting_statement",
     ),
     # Operations
-    re_path(
-        r"^operation/create/(?P<j_id>[0-9]+)$",
+    path(
+        "operation/create/<int:j_id>/",
         OperationCreateView.as_view(),
         name="op_new",
     ),
-    re_path(
-        r"^operation/(?P<op_id>[0-9]+)$", OperationEditView.as_view(), name="op_edit"
-    ),
-    re_path(
-        r"^operation/(?P<op_id>[0-9]+)/pdf$", OperationPDFView.as_view(), name="op_pdf"
-    ),
+    path("operation/<int:op_id>/", OperationEditView.as_view(), name="op_edit"),
+    path("operation/<int:op_id>/pdf/", OperationPDFView.as_view(), name="op_pdf"),
     # Companies
-    re_path(r"^company/list$", CompanyListView.as_view(), name="co_list"),
-    re_path(r"^company/create$", CompanyCreateView.as_view(), name="co_new"),
-    re_path(r"^company/(?P<co_id>[0-9]+)$", CompanyEditView.as_view(), name="co_edit"),
+    path("company/list/", CompanyListView.as_view(), name="co_list"),
+    path("company/create/", CompanyCreateView.as_view(), name="co_new"),
+    path("company/<int:co_id>/", CompanyEditView.as_view(), name="co_edit"),
     # Labels
-    re_path(r"^label/new$", LabelCreateView.as_view(), name="label_new"),
-    re_path(
-        r"^label/(?P<clubaccount_id>[0-9]+)$",
+    path("label/new/", LabelCreateView.as_view(), name="label_new"),
+    path(
+        "label/<int:clubaccount_id>/",
         LabelListView.as_view(),
         name="label_list",
     ),
-    re_path(
-        r"^label/(?P<label_id>[0-9]+)/edit$", LabelEditView.as_view(), name="label_edit"
-    ),
-    re_path(
-        r"^label/(?P<label_id>[0-9]+)/delete$",
+    path("label/<int:label_id>/edit/", LabelEditView.as_view(), name="label_edit"),
+    path(
+        "label/<int:label_id>/delete/",
         LabelDeleteView.as_view(),
         name="label_delete",
     ),
     # User account
-    re_path(r"^refound/account$", RefoundAccountView.as_view(), name="refound_account"),
+    path("refound/account/", RefoundAccountView.as_view(), name="refound_account"),
 ]

--- a/club/urls.py
+++ b/club/urls.py
@@ -23,94 +23,84 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from club.views import *
 
 urlpatterns = [
-    re_path(r"^$", ClubListView.as_view(), name="club_list"),
-    re_path(r"^new$", ClubCreateView.as_view(), name="club_new"),
-    re_path(r"^stats$", ClubStatView.as_view(), name="club_stats"),
-    re_path(r"^(?P<club_id>[0-9]+)/$", ClubView.as_view(), name="club_view"),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/rev/(?P<rev_id>[0-9]+)/$",
+    path("", ClubListView.as_view(), name="club_list"),
+    path("new/", ClubCreateView.as_view(), name="club_new"),
+    path("stats/", ClubStatView.as_view(), name="club_stats"),
+    path("<int:club_id>/", ClubView.as_view(), name="club_view"),
+    path(
+        "<int:club_id>/rev/<int:rev_id>/",
         ClubRevView.as_view(),
         name="club_view_rev",
     ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/hist$", ClubPageHistView.as_view(), name="club_hist"
-    ),
-    re_path(r"^(?P<club_id>[0-9]+)/edit$", ClubEditView.as_view(), name="club_edit"),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/edit/page$",
+    path("<int:club_id>/hist/", ClubPageHistView.as_view(), name="club_hist"),
+    path("<int:club_id>/edit/", ClubEditView.as_view(), name="club_edit"),
+    path(
+        "<int:club_id>/edit/page/",
         ClubPageEditView.as_view(),
         name="club_edit_page",
     ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/members$", ClubMembersView.as_view(), name="club_members"
-    ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/elderlies$",
+    path("<int:club_id>/members/", ClubMembersView.as_view(), name="club_members"),
+    path(
+        "<int:club_id>/elderlies/",
         ClubOldMembersView.as_view(),
         name="club_old_members",
     ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/sellings$",
+    path(
+        "<int:club_id>/sellings/",
         ClubSellingView.as_view(),
         name="club_sellings",
     ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/sellings/csv$",
+    path(
+        "<int:club_id>/sellings/csv/",
         ClubSellingCSVView.as_view(),
         name="sellings_csv",
     ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/prop$", ClubEditPropView.as_view(), name="club_prop"
-    ),
-    re_path(r"^(?P<club_id>[0-9]+)/tools$", ClubToolsView.as_view(), name="tools"),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/mailing$", ClubMailingView.as_view(), name="mailing"
-    ),
-    re_path(
-        r"^(?P<mailing_id>[0-9]+)/mailing/generate$",
+    path("<int:club_id>/prop/", ClubEditPropView.as_view(), name="club_prop"),
+    path("<int:club_id>/tools/", ClubToolsView.as_view(), name="tools"),
+    path("<int:club_id>/mailing/", ClubMailingView.as_view(), name="mailing"),
+    path(
+        "<int:mailing_id>/mailing/generate/",
         MailingAutoGenerationView.as_view(),
         name="mailing_generate",
     ),
-    re_path(
-        r"^(?P<mailing_id>[0-9]+)/mailing/delete$",
+    path(
+        "<int:mailing_id>/mailing/delete/",
         MailingDeleteView.as_view(),
         name="mailing_delete",
     ),
-    re_path(
-        r"^(?P<mailing_subscription_id>[0-9]+)/mailing/delete/subscription$",
+    path(
+        "<int:mailing_subscription_id>/mailing/delete/subscription/",
         MailingSubscriptionDeleteView.as_view(),
         name="mailing_subscription_delete",
     ),
-    re_path(
-        r"^membership/(?P<membership_id>[0-9]+)/set_old$",
+    path(
+        "membership/<int:membership_id>/set_old/",
         MembershipSetOldView.as_view(),
         name="membership_set_old",
     ),
-    re_path(
-        r"^membership/(?P<membership_id>[0-9]+)/delete$",
+    path(
+        "membership/<int:membership_id>/delete/",
         MembershipDeleteView.as_view(),
         name="membership_delete",
     ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/poster$", PosterListView.as_view(), name="poster_list"
-    ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/poster/create$",
+    path("<int:club_id>/poster/", PosterListView.as_view(), name="poster_list"),
+    path(
+        "<int:club_id>/poster/create/",
         PosterCreateView.as_view(),
         name="poster_create",
     ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/poster/(?P<poster_id>[0-9]+)/edit$",
+    path(
+        "<int:club_id>/poster/<int:poster_id>/edit/",
         PosterEditView.as_view(),
         name="poster_edit",
     ),
-    re_path(
-        r"^(?P<club_id>[0-9]+)/poster/(?P<poster_id>[0-9]+)/delete$",
+    path(
+        "<int:club_id>/poster/<int:poster_id>/delete/",
         PosterDeleteView.as_view(),
         name="poster_delete",
     ),

--- a/com/urls.py
+++ b/com/urls.py
@@ -22,104 +22,98 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
-from com.views import *
 from club.views import MailingDeleteView
+from com.views import *
 
 urlpatterns = [
-    re_path(r"^sith/edit/alert$", AlertMsgEditView.as_view(), name="alert_edit"),
-    re_path(r"^sith/edit/info$", InfoMsgEditView.as_view(), name="info_edit"),
-    re_path(
-        r"^sith/edit/weekmail_destinations$",
+    path("sith/edit/alert/", AlertMsgEditView.as_view(), name="alert_edit"),
+    path("sith/edit/info/", InfoMsgEditView.as_view(), name="info_edit"),
+    path(
+        "sith/edit/weekmail_destinations/",
         WeekmailDestinationEditView.as_view(),
         name="weekmail_destinations",
     ),
-    re_path(r"^weekmail$", WeekmailEditView.as_view(), name="weekmail"),
-    re_path(
-        r"^weekmail/preview$", WeekmailPreviewView.as_view(), name="weekmail_preview"
-    ),
-    re_path(
-        r"^weekmail/new_article$",
+    path("weekmail/", WeekmailEditView.as_view(), name="weekmail"),
+    path("weekmail/preview/", WeekmailPreviewView.as_view(), name="weekmail_preview"),
+    path(
+        "weekmail/new_article/",
         WeekmailArticleCreateView.as_view(),
         name="weekmail_article",
     ),
-    re_path(
-        r"^weekmail/article/(?P<article_id>[0-9]+)/delete$",
+    path(
+        "weekmail/article/<int:article_id>/delete/",
         WeekmailArticleDeleteView.as_view(),
         name="weekmail_article_delete",
     ),
-    re_path(
-        r"^weekmail/article/(?P<article_id>[0-9]+)/edit$",
+    path(
+        "weekmail/article/<int:article_id>/edit/",
         WeekmailArticleEditView.as_view(),
         name="weekmail_article_edit",
     ),
-    re_path(r"^news$", NewsListView.as_view(), name="news_list"),
-    re_path(r"^news/admin$", NewsAdminListView.as_view(), name="news_admin_list"),
-    re_path(r"^news/create$", NewsCreateView.as_view(), name="news_new"),
-    re_path(
-        r"^news/(?P<news_id>[0-9]+)/delete$",
+    path("news/", NewsListView.as_view(), name="news_list"),
+    path("news/admin/", NewsAdminListView.as_view(), name="news_admin_list"),
+    path("news/create/", NewsCreateView.as_view(), name="news_new"),
+    path(
+        "news/<int:news_id>/delete/",
         NewsDeleteView.as_view(),
         name="news_delete",
     ),
-    re_path(
-        r"^news/(?P<news_id>[0-9]+)/moderate$",
+    path(
+        "news/<int:news_id>/moderate/",
         NewsModerateView.as_view(),
         name="news_moderate",
     ),
-    re_path(
-        r"^news/(?P<news_id>[0-9]+)/edit$", NewsEditView.as_view(), name="news_edit"
-    ),
-    re_path(
-        r"^news/(?P<news_id>[0-9]+)$", NewsDetailView.as_view(), name="news_detail"
-    ),
-    re_path(r"^mailings$", MailingListAdminView.as_view(), name="mailing_admin"),
-    re_path(
-        r"^mailings/(?P<mailing_id>[0-9]+)/moderate$",
+    path("news/<int:news_id>/edit/", NewsEditView.as_view(), name="news_edit"),
+    path("news/<int:news_id>/", NewsDetailView.as_view(), name="news_detail"),
+    path("mailings/", MailingListAdminView.as_view(), name="mailing_admin"),
+    path(
+        "mailings/<int:mailing_id>/moderate/",
         MailingModerateView.as_view(),
         name="mailing_moderate",
     ),
-    re_path(
-        r"^mailings/(?P<mailing_id>[0-9]+)/delete$",
+    path(
+        "mailings/<int:mailing_id>/delete/",
         MailingDeleteView.as_view(redirect_page="com:mailing_admin"),
         name="mailing_delete",
     ),
-    re_path(r"^poster$", PosterListView.as_view(), name="poster_list"),
-    re_path(r"^poster/create$", PosterCreateView.as_view(), name="poster_create"),
-    re_path(
-        r"^poster/(?P<poster_id>[0-9]+)/edit$",
+    path("poster/", PosterListView.as_view(), name="poster_list"),
+    path("poster/create/", PosterCreateView.as_view(), name="poster_create"),
+    path(
+        "poster/<int:poster_id>/edit/",
         PosterEditView.as_view(),
         name="poster_edit",
     ),
-    re_path(
-        r"^poster/(?P<poster_id>[0-9]+)/delete$",
+    path(
+        "poster/<int:poster_id>/delete/",
         PosterDeleteView.as_view(),
         name="poster_delete",
     ),
-    re_path(
-        r"^poster/moderate$",
+    path(
+        "poster/moderate/",
         PosterModerateListView.as_view(),
         name="poster_moderate_list",
     ),
-    re_path(
-        r"^poster/(?P<object_id>[0-9]+)/moderate$",
+    path(
+        "poster/<int:object_id>/moderate/",
         PosterModerateView.as_view(),
         name="poster_moderate",
     ),
-    re_path(r"^screen$", ScreenListView.as_view(), name="screen_list"),
-    re_path(r"^screen/create$", ScreenCreateView.as_view(), name="screen_create"),
-    re_path(
-        r"^screen/(?P<screen_id>[0-9]+)/slideshow$",
+    path("screen/", ScreenListView.as_view(), name="screen_list"),
+    path("screen/create/", ScreenCreateView.as_view(), name="screen_create"),
+    path(
+        "screen/<int:screen_id>/slideshow/",
         ScreenSlideshowView.as_view(),
         name="screen_slideshow",
     ),
-    re_path(
-        r"^screen/(?P<screen_id>[0-9]+)/edit$",
+    path(
+        "screen/<int:screen_id>/edit/",
         ScreenEditView.as_view(),
         name="screen_edit",
     ),
-    re_path(
-        r"^screen/(?P<screen_id>[0-9]+)/delete$",
+    path(
+        "screen/<int:screen_id>/delete/",
         ScreenDeleteView.as_view(),
         name="screen_delete",
     ),

--- a/core/converters.py
+++ b/core/converters.py
@@ -1,0 +1,35 @@
+from core.models import Page
+
+
+class FourDigitYearConverter:
+    regex = "[0-9]{4}"
+
+    def to_python(self, value):
+        return int(value)
+
+    def to_url(self, value):
+        return str(value).zfill(4)
+
+
+class TwoDigitMonthConverter:
+    regex = "[0-9]{2}"
+
+    def to_python(self, value):
+        return int(value)
+
+    def to_url(self, value):
+        return str(value).zfill(2)
+
+
+class BooleanStringConverter:
+    """
+    Converter whose regex match either True or False
+    """
+
+    regex = r"(True)|(False)"
+
+    def to_python(self, value):
+        return str(value) == "True"
+
+    def to_url(self, value):
+        return str(value)

--- a/core/urls.py
+++ b/core/urls.py
@@ -23,40 +23,46 @@
 #
 #
 
-from django.urls import re_path, path
+from django.urls import path, re_path, register_converter
 
 from core.views import *
+from core.converters import (
+    FourDigitYearConverter,
+    TwoDigitMonthConverter,
+    BooleanStringConverter,
+)
+
+register_converter(FourDigitYearConverter, "yyyy")
+register_converter(TwoDigitMonthConverter, "mm")
+register_converter(BooleanStringConverter, "bool")
+
 
 urlpatterns = [
-    re_path(r"^$", index, name="index"),
-    re_path(r"^to_markdown$", ToMarkdownView.as_view(), name="to_markdown"),
-    re_path(r"^notifications$", NotificationList.as_view(), name="notification_list"),
-    re_path(r"^notification/(?P<notif_id>[0-9]+)$", notification, name="notification"),
+    path("", index, name="index"),
+    path("to_markdown/", ToMarkdownView.as_view(), name="to_markdown"),
+    path("notifications/", NotificationList.as_view(), name="notification_list"),
+    path("notification/<int:notif_id>/", notification, name="notification"),
     # Search
-    re_path(r"^search/$", search_view, name="search"),
-    re_path(r"^search_json/$", search_json, name="search_json"),
-    re_path(r"^search_user/$", search_user_json, name="search_user"),
+    path("search/", search_view, name="search"),
+    path("search_json/", search_json, name="search_json"),
+    path("search_user/", search_user_json, name="search_user"),
     # Login and co
-    re_path(r"^login/$", SithLoginView.as_view(), name="login"),
-    re_path(r"^logout/$", logout, name="logout"),
-    re_path(
-        r"^password_change/$", SithPasswordChangeView.as_view(), name="password_change"
-    ),
-    re_path(
-        r"^password_change/(?P<user_id>[0-9]+)$",
+    path("login/", SithLoginView.as_view(), name="login"),
+    path("logout/", logout, name="logout"),
+    path("password_change/", SithPasswordChangeView.as_view(), name="password_change"),
+    path(
+        "password_change/<int:user_id>/",
         password_root_change,
         name="password_root_change",
     ),
-    re_path(
-        r"^password_change/done$",
+    path(
+        "password_change/done/",
         SithPasswordChangeDoneView.as_view(),
         name="password_change_done",
     ),
-    re_path(
-        r"^password_reset/$", SithPasswordResetView.as_view(), name="password_reset"
-    ),
-    re_path(
-        r"^password_reset/done$",
+    path("password_reset/", SithPasswordResetView.as_view(), name="password_reset"),
+    path(
+        "password_reset/done/",
         SithPasswordResetDoneView.as_view(),
         name="password_reset_done",
     ),
@@ -65,110 +71,103 @@ urlpatterns = [
         SithPasswordResetConfirmView.as_view(),
         name="password_reset_confirm",
     ),
-    re_path(
-        r"^reset/done/$",
+    path(
+        "reset/done/",
         SithPasswordResetCompleteView.as_view(),
         name="password_reset_complete",
     ),
-    re_path(r"^register$", register, name="register"),
+    path("register/", register, name="register"),
     # Group handling
-    re_path(r"^group/$", GroupListView.as_view(), name="group_list"),
-    re_path(r"^group/new/$", GroupCreateView.as_view(), name="group_new"),
-    re_path(
-        r"^group/(?P<group_id>[0-9]+)/$", GroupEditView.as_view(), name="group_edit"
-    ),
-    re_path(
-        r"^group/(?P<group_id>[0-9]+)/delete$",
+    path("group/", GroupListView.as_view(), name="group_list"),
+    path("group/new/", GroupCreateView.as_view(), name="group_new"),
+    path("group/<int:group_id>/", GroupEditView.as_view(), name="group_edit"),
+    path(
+        "group/<int:group_id>/delete/",
         GroupDeleteView.as_view(),
         name="group_delete",
     ),
-    re_path(
-        r"^group/(?P<group_id>[0-9]+)/detail$",
+    path(
+        "group/<int:group_id>/detail/",
         GroupTemplateView.as_view(),
         name="group_detail",
     ),
     # User views
-    re_path(r"^user/$", UserListView.as_view(), name="user_list"),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/mini$",
+    path("user/", UserListView.as_view(), name="user_list"),
+    path(
+        "user/<int:user_id>/mini/",
         UserMiniView.as_view(),
         name="user_profile_mini",
     ),
-    re_path(r"^user/(?P<user_id>[0-9]+)/$", UserView.as_view(), name="user_profile"),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/pictures$",
+    path("user/<int:user_id>/", UserView.as_view(), name="user_profile"),
+    path(
+        "user/<int:user_id>/pictures/",
         UserPicturesView.as_view(),
         name="user_pictures",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/godfathers$",
+    path(
+        "user/<int:user_id>/godfathers/",
         UserGodfathersView.as_view(),
         name="user_godfathers",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/godfathers/tree$",
+    path(
+        "user/<int:user_id>/godfathers/tree/",
         UserGodfathersTreeView.as_view(),
         name="user_godfathers_tree",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/godfathers/tree/pict$",
+    path(
+        "user/<int:user_id>/godfathers/tree/pict/",
         UserGodfathersTreePictureView.as_view(),
         name="user_godfathers_tree_pict",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/godfathers/(?P<godfather_id>[0-9]+)/(?P<is_father>(True)|(False))/delete$",
-        DeleteUserGodfathers,
+    path(
+        "user/<int:user_id>/godfathers/<int:godfather_id>/<bool:is_father>/delete/",
+        delete_user_godfather,
         name="user_godfathers_delete",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/edit$",
+    path(
+        "user/<int:user_id>/edit/",
         UserUpdateProfileView.as_view(),
         name="user_edit",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/profile_upload$",
+    path(
+        "user/<int:user_id>/profile_upload/",
         UserUploadProfilePictView.as_view(),
         name="user_profile_upload",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/clubs$", UserClubView.as_view(), name="user_clubs"
-    ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/prefs$",
+    path("user/<int:user_id>/clubs/", UserClubView.as_view(), name="user_clubs"),
+    path(
+        "user/<int:user_id>/prefs/",
         UserPreferencesView.as_view(),
         name="user_prefs",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/groups$",
+    path(
+        "user/<int:user_id>/groups/",
         UserUpdateGroupView.as_view(),
         name="user_groups",
     ),
-    re_path(r"^user/tools/$", UserToolsView.as_view(), name="user_tools"),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/account$",
+    path("user/tools/", UserToolsView.as_view(), name="user_tools"),
+    path(
+        "user/<int:user_id>/account/",
         UserAccountView.as_view(),
         name="user_account",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/account/(?P<year>[0-9]+)/(?P<month>[0-9]+)$",
+    path(
+        "user/<int:user_id>/account/<yyyy:year>/<mm:month>/",
         UserAccountDetailView.as_view(),
         name="user_account_detail",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/stats$", UserStatsView.as_view(), name="user_stats"
-    ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/gift/create$",
+    path("user/<int:user_id>/stats/", UserStatsView.as_view(), name="user_stats"),
+    path(
+        "user/<int:user_id>/gift/create/",
         GiftCreateView.as_view(),
         name="user_gift_create",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/gift/delete/(?P<gift_id>[0-9]+)/$",
+    path(
+        "user/<int:user_id>/gift/delete/<int:gift_id>/",
         GiftDeleteView.as_view(),
         name="user_gift_delete",
     ),
     # File views
-    # re_path(r'^file/add/(?P<popup>popup)?$', FileCreateView.as_view(), name='file_new'),
     re_path(r"^file/(?P<popup>popup)?$", FileListView.as_view(), name="file_list"),
     re_path(
         r"^file/(?P<file_id>[0-9]+)/(?P<popup>popup)?$",
@@ -190,43 +189,43 @@ urlpatterns = [
         FileDeleteView.as_view(),
         name="file_delete",
     ),
-    re_path(r"^file/moderation$", FileModerationView.as_view(), name="file_moderation"),
-    re_path(
-        r"^file/(?P<file_id>[0-9]+)/moderate$",
+    path("file/moderation/", FileModerationView.as_view(), name="file_moderation"),
+    path(
+        "file/<int:file_id>/moderate/",
         FileModerateView.as_view(),
         name="file_moderate",
     ),
-    re_path(r"^file/(?P<file_id>[0-9]+)/download$", send_file, name="download"),
+    path("file/<int:file_id>/download/", send_file, name="download"),
     # Page views
-    re_path(r"^page/$", PageListView.as_view(), name="page_list"),
-    re_path(r"^page/create$", PageCreateView.as_view(), name="page_new"),
-    re_path(
-        r"^page/(?P<page_id>[0-9]*)/delete$",
+    path("page/", PageListView.as_view(), name="page_list"),
+    path("page/create/", PageCreateView.as_view(), name="page_new"),
+    path(
+        "page/<int:page_id>/delete/",
         PageDeleteView.as_view(),
         name="page_delete",
     ),
-    re_path(
-        r"^page/(?P<page_name>([/a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])+)/edit$",
+    path(
+        "page/<path:page_name>/edit/",
         PageEditView.as_view(),
         name="page_edit",
     ),
-    re_path(
-        r"^page/(?P<page_name>([/a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])+)/prop$",
+    path(
+        "page/<path:page_name>/prop/",
         PagePropView.as_view(),
         name="page_prop",
     ),
-    re_path(
-        r"^page/(?P<page_name>([/a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])+)/hist$",
+    path(
+        "page/<path:page_name>/hist/",
         PageHistView.as_view(),
         name="page_hist",
     ),
-    re_path(
-        r"^page/(?P<page_name>([/a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])+)/rev/(?P<rev>[0-9]+)/",
+    path(
+        "page/<path:page_name>/rev/<int:rev>/",
         PageRevView.as_view(),
         name="page_rev",
     ),
-    re_path(
-        r"^page/(?P<page_name>([/a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])+)/$",
+    path(
+        "page/<path:page_name>/",
         PageView.as_view(),
         name="page",
     ),

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -338,16 +338,16 @@ class UserPicturesView(UserTabsMixin, CanViewMixin, DetailView):
         return kwargs
 
 
-def DeleteUserGodfathers(request, user_id, godfather_id, is_father):
-    user = User.objects.get(id=user_id)
-    if (user == request.user) or request.user.is_root or request.user.is_board_member:
-        ud = get_object_or_404(User, id=godfather_id)
-        if is_father == "True":
-            user.godfathers.remove(ud)
-        else:
-            user.godchildren.remove(ud)
+def delete_user_godfather(request, user_id, godfather_id, is_father):
+    user_is_admin = request.user.is_root or request.user.is_board_member
+    if user_id != request.user.id and not user_is_admin:
+        raise PermissionDenied()
+    user = get_object_or_404(User, id=user_id)
+    to_remove = get_object_or_404(User, id=godfather_id)
+    if is_father:
+        user.godfathers.remove(to_remove)
     else:
-        raise PermissionDenied
+        user.godchildren.remove(to_remove)
     return redirect("core:user_godfathers", user_id=user_id)
 
 

--- a/counter/urls.py
+++ b/counter/urls.py
@@ -22,47 +22,47 @@
 #
 #
 
-from django.urls import re_path, path
+from django.urls import path
 
 from counter.views import *
 
 urlpatterns = [
-    re_path(r"^(?P<counter_id>[0-9]+)$", CounterMain.as_view(), name="details"),
-    re_path(
-        r"^(?P<counter_id>[0-9]+)/click/(?P<user_id>[0-9]+)$",
+    path("<int:counter_id>/", CounterMain.as_view(), name="details"),
+    path(
+        "<int:counter_id>/click/<int:user_id>/",
         CounterClick.as_view(),
         name="click",
     ),
-    re_path(
-        r"^(?P<counter_id>[0-9]+)/last_ops$",
+    path(
+        "<int:counter_id>/last_ops/",
         CounterLastOperationsView.as_view(),
         name="last_ops",
     ),
-    re_path(
-        r"^(?P<counter_id>[0-9]+)/cash_summary$",
+    path(
+        "<int:counter_id>/cash_summary/",
         CounterCashSummaryView.as_view(),
         name="cash_summary",
     ),
-    re_path(
-        r"^(?P<counter_id>[0-9]+)/activity$",
+    path(
+        "<int:counter_id>/activity/",
         CounterActivityView.as_view(),
         name="activity",
     ),
-    re_path(r"^(?P<counter_id>[0-9]+)/stats$", CounterStatView.as_view(), name="stats"),
-    re_path(r"^(?P<counter_id>[0-9]+)/login$", CounterLogin.as_view(), name="login"),
-    re_path(r"^(?P<counter_id>[0-9]+)/logout$", CounterLogout.as_view(), name="logout"),
-    re_path(
-        r"^eticket/(?P<selling_id>[0-9]+)/pdf$",
+    path("<int:counter_id>/stats/", CounterStatView.as_view(), name="stats"),
+    path("<int:counter_id>/login/", CounterLogin.as_view(), name="login"),
+    path("<int:counter_id>/logout/", CounterLogout.as_view(), name="logout"),
+    path(
+        "eticket/<int:selling_id>/pdf/",
         EticketPDFView.as_view(),
         name="eticket_pdf",
     ),
-    re_path(
-        r"^customer/(?P<customer_id>[0-9]+)/card/add$",
+    path(
+        "customer/<int:customer_id>/card/add/",
         StudentCardFormView.as_view(),
         name="add_student_card",
     ),
-    re_path(
-        r"^customer/(?P<customer_id>[0-9]+)/card/delete/(?P<card_id>[0-9]+)/$",
+    path(
+        "customer/<int:customer_id>/card/delete/<int:card_id>/",
         StudentCardDeleteView.as_view(),
         name="delete_student_card",
     ),
@@ -76,76 +76,76 @@ urlpatterns = [
         edit_billing_info,
         name="edit_billing_info",
     ),
-    re_path(r"^admin/(?P<counter_id>[0-9]+)$", CounterEditView.as_view(), name="admin"),
-    re_path(
-        r"^admin/(?P<counter_id>[0-9]+)/prop$",
+    path("admin/<int:counter_id>/", CounterEditView.as_view(), name="admin"),
+    path(
+        "admin/<int:counter_id>/prop/",
         CounterEditPropView.as_view(),
         name="prop_admin",
     ),
-    re_path(r"^admin$", CounterListView.as_view(), name="admin_list"),
-    re_path(r"^admin/new$", CounterCreateView.as_view(), name="new"),
-    re_path(
-        r"^admin/delete/(?P<counter_id>[0-9]+)$",
+    path("admin/", CounterListView.as_view(), name="admin_list"),
+    path("admin/new/", CounterCreateView.as_view(), name="new"),
+    path(
+        "admin/delete/<int:counter_id>/",
         CounterDeleteView.as_view(),
         name="delete",
     ),
-    re_path(r"^admin/invoices_call$", InvoiceCallView.as_view(), name="invoices_call"),
-    re_path(
-        r"^admin/cash_summary/list$",
+    path("admin/invoices_call/", InvoiceCallView.as_view(), name="invoices_call"),
+    path(
+        "admin/cash_summary/list/",
         CashSummaryListView.as_view(),
         name="cash_summary_list",
     ),
-    re_path(
-        r"^admin/cash_summary/(?P<cashsummary_id>[0-9]+)$",
+    path(
+        "admin/cash_summary/<int:cashsummary_id>/",
         CashSummaryEditView.as_view(),
         name="cash_summary_edit",
     ),
-    re_path(r"^admin/product/list$", ProductListView.as_view(), name="product_list"),
-    re_path(
-        r"^admin/product/list_archived$",
+    path("admin/product/list/", ProductListView.as_view(), name="product_list"),
+    path(
+        "admin/product/list_archived/",
         ProductArchivedListView.as_view(),
         name="product_list_archived",
     ),
-    re_path(r"^admin/product/create$", ProductCreateView.as_view(), name="new_product"),
-    re_path(
-        r"^admin/product/(?P<product_id>[0-9]+)$",
+    path("admin/product/create/", ProductCreateView.as_view(), name="new_product"),
+    path(
+        "admin/product/<int:product_id>/",
         ProductEditView.as_view(),
         name="product_edit",
     ),
-    re_path(
-        r"^admin/producttype/list$",
+    path(
+        "admin/producttype/list/",
         ProductTypeListView.as_view(),
         name="producttype_list",
     ),
-    re_path(
-        r"^admin/producttype/create$",
+    path(
+        "admin/producttype/create/",
         ProductTypeCreateView.as_view(),
         name="new_producttype",
     ),
-    re_path(
-        r"^admin/producttype/(?P<type_id>[0-9]+)$",
+    path(
+        "admin/producttype/<int:type_id>/",
         ProductTypeEditView.as_view(),
         name="producttype_edit",
     ),
-    re_path(r"^admin/eticket/list$", EticketListView.as_view(), name="eticket_list"),
-    re_path(r"^admin/eticket/new$", EticketCreateView.as_view(), name="new_eticket"),
-    re_path(
-        r"^admin/eticket/(?P<eticket_id>[0-9]+)$",
+    path("admin/eticket/list/", EticketListView.as_view(), name="eticket_list"),
+    path("admin/eticket/new/", EticketCreateView.as_view(), name="new_eticket"),
+    path(
+        "admin/eticket/<int:eticket_id>/",
         EticketEditView.as_view(),
         name="edit_eticket",
     ),
-    re_path(
-        r"^admin/selling/(?P<selling_id>[0-9]+)/delete$",
+    path(
+        "admin/selling/<int:selling_id>/delete/",
         SellingDeleteView.as_view(),
         name="selling_delete",
     ),
-    re_path(
-        r"^admin/refilling/(?P<refilling_id>[0-9]+)/delete$",
+    path(
+        "admin/refilling/<int:refilling_id>/delete/",
         RefillingDeleteView.as_view(),
         name="refilling_delete",
     ),
-    re_path(
-        r"^admin/(?P<counter_id>[0-9]+)/refillings$",
+    path(
+        "admin/<int:counter_id>/refillings/",
         CounterRefillingListView.as_view(),
         name="refilling_list",
     ),

--- a/election/urls.py
+++ b/election/urls.py
@@ -1,57 +1,49 @@
-from django.urls import re_path
+from django.urls import path
 
 from election.views import *
 
 urlpatterns = [
-    re_path(r"^$", ElectionsListView.as_view(), name="list"),
-    re_path(r"^archived$", ElectionListArchivedView.as_view(), name="list_archived"),
-    re_path(r"^add$", ElectionCreateView.as_view(), name="create"),
-    re_path(
-        r"^(?P<election_id>[0-9]+)/edit$", ElectionUpdateView.as_view(), name="update"
-    ),
-    re_path(
-        r"^(?P<election_id>[0-9]+)/delete$", ElectionDeleteView.as_view(), name="delete"
-    ),
-    re_path(
-        r"^(?P<election_id>[0-9]+)/list/add$",
+    path("", ElectionsListView.as_view(), name="list"),
+    path("archived/", ElectionListArchivedView.as_view(), name="list_archived"),
+    path("add/", ElectionCreateView.as_view(), name="create"),
+    path("<int:election_id>/edit/", ElectionUpdateView.as_view(), name="update"),
+    path("<int:election_id>/delete/", ElectionDeleteView.as_view(), name="delete"),
+    path(
+        "<int:election_id>/list/add/",
         ElectionListCreateView.as_view(),
         name="create_list",
     ),
-    re_path(
-        r"^(?P<list_id>[0-9]+)/list/delete$",
+    path(
+        "<int:list_id>/list/delete/",
         ElectionListDeleteView.as_view(),
         name="delete_list",
     ),
-    re_path(
-        r"^(?P<election_id>[0-9]+)/role/create$",
+    path(
+        "<int:election_id>/role/create/",
         RoleCreateView.as_view(),
         name="create_role",
     ),
-    re_path(
-        r"^(?P<role_id>[0-9]+)/role/edit$", RoleUpdateView.as_view(), name="update_role"
-    ),
-    re_path(
-        r"^(?P<role_id>[0-9]+)/role/delete$",
+    path("<int:role_id>/role/edit/", RoleUpdateView.as_view(), name="update_role"),
+    path(
+        "<int:role_id>/role/delete/",
         RoleDeleteView.as_view(),
         name="delete_role",
     ),
-    re_path(
-        r"^(?P<election_id>[0-9]+)/candidate/add$",
+    path(
+        "<int:election_id>/candidate/add/",
         CandidatureCreateView.as_view(),
         name="candidate",
     ),
-    re_path(
-        r"^(?P<candidature_id>[0-9]+)/candidate/edit$",
+    path(
+        "<int:candidature_id>/candidate/edit/",
         CandidatureUpdateView.as_view(),
         name="update_candidate",
     ),
-    re_path(
-        r"^(?P<candidature_id>[0-9]+)/candidate/delete$",
+    path(
+        "<int:candidature_id>/candidate/delete/",
         CandidatureDeleteView.as_view(),
         name="delete_candidate",
     ),
-    re_path(r"^(?P<election_id>[0-9]+)/vote$", VoteFormView.as_view(), name="vote"),
-    re_path(
-        r"^(?P<election_id>[0-9]+)/detail$", ElectionDetailView.as_view(), name="detail"
-    ),
+    path("<int:election_id>/vote/", VoteFormView.as_view(), name="vote"),
+    path("<int:election_id>/detail/", ElectionDetailView.as_view(), name="detail"),
 ]

--- a/forum/urls.py
+++ b/forum/urls.py
@@ -22,69 +22,62 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from forum.views import *
 
-
 urlpatterns = [
-    re_path(r"^$", ForumMainView.as_view(), name="main"),
-    re_path(r"^search/$", ForumSearchView.as_view(), name="search"),
-    re_path(r"^new_forum$", ForumCreateView.as_view(), name="new_forum"),
-    re_path(
-        r"^mark_all_as_read$", ForumMarkAllAsRead.as_view(), name="mark_all_as_read"
-    ),
-    re_path(r"^last_unread$", ForumLastUnread.as_view(), name="last_unread"),
-    re_path(
-        r"^favorite_topics$", ForumFavoriteTopics.as_view(), name="favorite_topics"
-    ),
-    re_path(r"^(?P<forum_id>[0-9]+)$", ForumDetailView.as_view(), name="view_forum"),
-    re_path(r"^(?P<forum_id>[0-9]+)/edit$", ForumEditView.as_view(), name="edit_forum"),
-    re_path(
-        r"^(?P<forum_id>[0-9]+)/delete$", ForumDeleteView.as_view(), name="delete_forum"
-    ),
-    re_path(
-        r"^(?P<forum_id>[0-9]+)/new_topic$",
+    path("", ForumMainView.as_view(), name="main"),
+    path("search/", ForumSearchView.as_view(), name="search"),
+    path("new_forum/", ForumCreateView.as_view(), name="new_forum"),
+    path("mark_all_as_read/", ForumMarkAllAsRead.as_view(), name="mark_all_as_read"),
+    path("last_unread/", ForumLastUnread.as_view(), name="last_unread"),
+    path("favorite_topics/", ForumFavoriteTopics.as_view(), name="favorite_topics"),
+    path("<int:forum_id>/", ForumDetailView.as_view(), name="view_forum"),
+    path("<int:forum_id>/edit/", ForumEditView.as_view(), name="edit_forum"),
+    path("<int:forum_id>/delete/", ForumDeleteView.as_view(), name="delete_forum"),
+    path(
+        "<int:forum_id>/new_topic/",
         ForumTopicCreateView.as_view(),
         name="new_topic",
     ),
-    re_path(
-        r"^topic/(?P<topic_id>[0-9]+)$",
+    path(
+        "topic/<int:topic_id>/",
         ForumTopicDetailView.as_view(),
         name="view_topic",
     ),
-    re_path(
-        r"^topic/(?P<topic_id>[0-9]+)/edit$",
+    path(
+        "topic/<int:topic_id>/edit/",
         ForumTopicEditView.as_view(),
         name="edit_topic",
     ),
-    re_path(
-        r"^topic/(?P<topic_id>[0-9]+)/new_message$",
+    path(
+        "topic/<int:topic_id>/new_message/",
         ForumMessageCreateView.as_view(),
         name="new_message",
     ),
-    re_path(
-        r"^topic/(?P<topic_id>[0-9]+)/toggle_subscribe$",
+    path(
+        "topic/<int:topic_id>/toggle_subscribe/",
         ForumTopicSubscribeView.as_view(),
         name="toggle_subscribe_topic",
     ),
-    re_path(
-        r"^message/(?P<message_id>[0-9]+)$",
+    path(
+        "message/<int:message_id>/",
         ForumMessageView.as_view(),
         name="view_message",
     ),
-    re_path(
-        r"^message/(?P<message_id>[0-9]+)/edit$",
+    path(
+        "message/<int:message_id>/edit/",
         ForumMessageEditView.as_view(),
         name="edit_message",
     ),
-    re_path(
-        r"^message/(?P<message_id>[0-9]+)/delete$",
+    path(
+        "message/<int:message_id>/delete/",
         ForumMessageDeleteView.as_view(),
         name="delete_message",
     ),
-    re_path(
-        r"^message/(?P<message_id>[0-9]+)/undelete$",
+    path(
+        "message/<int:message_id>/undelete/",
         ForumMessageUndeleteView.as_view(),
         name="undelete_message",
     ),

--- a/launderette/urls.py
+++ b/launderette/urls.py
@@ -22,54 +22,54 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from launderette.views import *
 
 urlpatterns = [
     # views
-    re_path(r"^$", LaunderetteMainView.as_view(), name="launderette_main"),
-    re_path(
-        r"^slot/(?P<slot_id>[0-9]+)/delete$",
+    path("", LaunderetteMainView.as_view(), name="launderette_main"),
+    path(
+        "slot/<int:slot_id>/delete/",
         SlotDeleteView.as_view(),
         name="delete_slot",
     ),
-    re_path(r"^book$", LaunderetteBookMainView.as_view(), name="book_main"),
-    re_path(
-        r"^book/(?P<launderette_id>[0-9]+)$",
+    path("book/", LaunderetteBookMainView.as_view(), name="book_main"),
+    path(
+        "book/<int:launderette_id>/",
         LaunderetteBookView.as_view(),
         name="book_slot",
     ),
-    re_path(
-        r"^(?P<launderette_id>[0-9]+)/click$",
+    path(
+        "<int:launderette_id>/click/",
         LaunderetteMainClickView.as_view(),
         name="main_click",
     ),
-    re_path(
-        r"^(?P<launderette_id>[0-9]+)/click/(?P<user_id>[0-9]+)$",
+    path(
+        "<int:launderette_id>/click/<int:user_id>/",
         LaunderetteClickView.as_view(),
         name="click",
     ),
-    re_path(r"^admin$", LaunderetteListView.as_view(), name="launderette_list"),
-    re_path(
-        r"^admin/(?P<launderette_id>[0-9]+)$",
+    path("admin/", LaunderetteListView.as_view(), name="launderette_list"),
+    path(
+        "admin/<int:launderette_id>/",
         LaunderetteAdminView.as_view(),
         name="launderette_admin",
     ),
-    re_path(
-        r"^admin/(?P<launderette_id>[0-9]+)/edit$",
+    path(
+        "admin/<int:launderette_id>/edit/",
         LaunderetteEditView.as_view(),
         name="launderette_edit",
     ),
-    re_path(r"^admin/new$", LaunderetteCreateView.as_view(), name="launderette_new"),
-    re_path(r"^admin/machine/new$", MachineCreateView.as_view(), name="machine_new"),
-    re_path(
-        r"^admin/machine/(?P<machine_id>[0-9]+)/edit$",
+    path("admin/new/", LaunderetteCreateView.as_view(), name="launderette_new"),
+    path("admin/machine/new/", MachineCreateView.as_view(), name="machine_new"),
+    path(
+        "admin/machine/<int:machine_id>/edit/",
         MachineEditView.as_view(),
         name="machine_edit",
     ),
-    re_path(
-        r"^admin/machine/(?P<machine_id>[0-9]+)/delete$",
+    path(
+        "admin/machine/<int:machine_id>/delete/",
         MachineDeleteView.as_view(),
         name="machine_delete",
     ),

--- a/matmat/urls.py
+++ b/matmat/urls.py
@@ -22,13 +22,13 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from matmat.views import *
 
 urlpatterns = [
-    re_path(r"^$", SearchNormalFormView.as_view(), name="search"),
-    re_path(r"^reverse$", SearchReverseFormView.as_view(), name="search_reverse"),
-    re_path(r"^quick$", SearchQuickFormView.as_view(), name="search_quick"),
-    re_path(r"^clear$", SearchClearFormView.as_view(), name="search_clear"),
+    path("", SearchNormalFormView.as_view(), name="search"),
+    path("reverse/", SearchReverseFormView.as_view(), name="search_reverse"),
+    path("quick/", SearchQuickFormView.as_view(), name="search_quick"),
+    path("clear/", SearchClearFormView.as_view(), name="search_clear"),
 ]

--- a/pedagogy/tests.py
+++ b/pedagogy/tests.py
@@ -732,9 +732,9 @@ class UVSearchTest(TestCase):
             [
                 {
                     "id": 1,
-                    "absolute_url": "/pedagogy/uv/1",
-                    "update_url": "/pedagogy/uv/1/edit",
-                    "delete_url": "/pedagogy/uv/1/delete",
+                    "absolute_url": "/pedagogy/uv/1/",
+                    "update_url": "/pedagogy/uv/1/edit/",
+                    "delete_url": "/pedagogy/uv/1/delete/",
                     "code": "PA00",
                     "author": 0,
                     "credit_type": "OM",

--- a/pedagogy/urls.py
+++ b/pedagogy/urls.py
@@ -22,33 +22,33 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from pedagogy.views import *
 
 urlpatterns = [
     # Urls displaying the actual application for visitors
-    re_path(r"^$", UVListView.as_view(), name="guide"),
-    re_path(r"^uv/(?P<uv_id>[0-9]+)$", UVDetailFormView.as_view(), name="uv_detail"),
-    re_path(
-        r"^comment/(?P<comment_id>[0-9]+)/edit$",
+    path("", UVListView.as_view(), name="guide"),
+    path("uv/<int:uv_id>/", UVDetailFormView.as_view(), name="uv_detail"),
+    path(
+        "comment/<int:comment_id>/edit/",
         UVCommentUpdateView.as_view(),
         name="comment_update",
     ),
-    re_path(
-        r"^comment/(?P<comment_id>[0-9]+)/delete$",
+    path(
+        "comment/<int:comment_id>/delete/",
         UVCommentDeleteView.as_view(),
         name="comment_delete",
     ),
-    re_path(
-        r"^comment/(?P<comment_id>[0-9]+)/report$",
+    path(
+        "comment/<int:comment_id>/report/",
         UVCommentReportCreateView.as_view(),
         name="comment_report",
     ),
     # Moderation
-    re_path(r"^moderation$", UVModerationFormView.as_view(), name="moderation"),
+    path("moderation/", UVModerationFormView.as_view(), name="moderation"),
     # Administration : Create Update Delete Edit
-    re_path(r"^uv/create$", UVCreateView.as_view(), name="uv_create"),
-    re_path(r"^uv/(?P<uv_id>[0-9]+)/delete$", UVDeleteView.as_view(), name="uv_delete"),
-    re_path(r"^uv/(?P<uv_id>[0-9]+)/edit$", UVUpdateView.as_view(), name="uv_update"),
+    path("uv/create/", UVCreateView.as_view(), name="uv_create"),
+    path("uv/<int:uv_id>/delete/", UVDeleteView.as_view(), name="uv_delete"),
+    path("uv/<int:uv_id>/edit/", UVUpdateView.as_view(), name="uv_update"),
 ]

--- a/rootplace/urls.py
+++ b/rootplace/urls.py
@@ -23,16 +23,16 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from rootplace.views import *
 
 urlpatterns = [
-    re_path(r"^merge$", MergeUsersView.as_view(), name="merge"),
-    re_path(
-        r"^forum/messages/delete$",
+    path("merge/", MergeUsersView.as_view(), name="merge"),
+    path(
+        "forum/messages/delete/",
         DeleteAllForumUserMessagesView.as_view(),
         name="delete_forum_messages",
     ),
-    re_path(r"^logs$", OperationLogListView.as_view(), name="operation_logs"),
+    path("logs/", OperationLogListView.as_view(), name="operation_logs"),
 ]

--- a/sas/urls.py
+++ b/sas/urls.py
@@ -22,40 +22,36 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from sas.views import *
 
 urlpatterns = [
-    re_path(r"^$", SASMainView.as_view(), name="main"),
-    re_path(r"^moderation$", ModerationView.as_view(), name="moderation"),
-    re_path(r"^album/(?P<album_id>[0-9]+)$", AlbumView.as_view(), name="album"),
-    re_path(
-        r"^album/(?P<album_id>[0-9]+)/upload$",
+    path("", SASMainView.as_view(), name="main"),
+    path("moderation/", ModerationView.as_view(), name="moderation"),
+    path("album/<int:album_id>/", AlbumView.as_view(), name="album"),
+    path(
+        "album/<int:album_id>/upload/",
         AlbumUploadView.as_view(),
         name="album_upload",
     ),
-    re_path(
-        r"^album/(?P<album_id>[0-9]+)/edit$", AlbumEditView.as_view(), name="album_edit"
-    ),
-    re_path(r"^album/(?P<album_id>[0-9]+)/preview$", send_album, name="album_preview"),
-    re_path(r"^picture/(?P<picture_id>[0-9]+)$", PictureView.as_view(), name="picture"),
-    re_path(
-        r"^picture/(?P<picture_id>[0-9]+)/edit$",
+    path("album/<int:album_id>/edit/", AlbumEditView.as_view(), name="album_edit"),
+    path("album/<int:album_id>/preview/", send_album, name="album_preview"),
+    path("picture/<int:picture_id>/", PictureView.as_view(), name="picture"),
+    path(
+        "picture/<int:picture_id>/edit/",
         PictureEditView.as_view(),
         name="picture_edit",
     ),
-    re_path(r"^picture/(?P<picture_id>[0-9]+)/download$", send_pict, name="download"),
-    re_path(
-        r"^picture/(?P<picture_id>[0-9]+)/download/compressed$",
+    path("picture/<int:picture_id>/download/", send_pict, name="download"),
+    path(
+        "picture/<int:picture_id>/download/compressed/",
         send_compressed,
         name="download_compressed",
     ),
-    re_path(
-        r"^picture/(?P<picture_id>[0-9]+)/download/thumb$",
+    path(
+        "picture/<int:picture_id>/download/thumb/",
         send_thumb,
         name="download_thumb",
     ),
-    # re_path(r'^album/new$', AlbumCreateView.as_view(), name='album_new'),
-    # re_path(r'^(?P<club_id>[0-9]+)/$', ClubView.as_view(), name='club_view'),
 ]

--- a/stock/urls.py
+++ b/stock/urls.py
@@ -23,67 +23,65 @@
 #
 #
 
-from django.urls import include, re_path
+from django.urls import path
 
 from stock.views import *
 
 urlpatterns = [
     # Stock re_paths
-    re_path(
-        r"^new/counter/(?P<counter_id>[0-9]+)$", StockCreateView.as_view(), name="new"
-    ),
-    re_path(r"^edit/(?P<stock_id>[0-9]+)$", StockEditView.as_view(), name="edit"),
-    re_path(r"^list$", StockListView.as_view(), name="list"),
+    path("new/counter/<int:counter_id>/", StockCreateView.as_view(), name="new"),
+    path("edit/<int:stock_id>/", StockEditView.as_view(), name="edit"),
+    path("list/", StockListView.as_view(), name="list"),
     # StockItem re_paths
-    re_path(r"^(?P<stock_id>[0-9]+)$", StockItemList.as_view(), name="items_list"),
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/stock_item/new_item$",
+    path("<int:stock_id>/", StockItemList.as_view(), name="items_list"),
+    path(
+        "<int:stock_id>/stock_item/new_item/",
         StockItemCreateView.as_view(),
         name="new_item",
     ),
-    re_path(
-        r"^stock_item/(?P<item_id>[0-9]+)/edit$",
+    path(
+        "stock_item/<int:item_id>/edit/",
         StockItemEditView.as_view(),
         name="edit_item",
     ),
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/stock_item/take_items$",
+    path(
+        "<int:stock_id>/stock_item/take_items/",
         StockTakeItemsBaseFormView.as_view(),
         name="take_items",
     ),
     # ShoppingList re_paths
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/shopping_list/list$",
+    path(
+        "<int:stock_id>/shopping_list/list/",
         StockShoppingListView.as_view(),
         name="shoppinglist_list",
     ),
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/shopping_list/create$",
+    path(
+        "<int:stock_id>/shopping_list/create/",
         StockItemQuantityBaseFormView.as_view(),
         name="shoppinglist_create",
     ),
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/shopping_list/(?P<shoppinglist_id>[0-9]+)/items$",
+    path(
+        "<int:stock_id>/shopping_list/<int:shoppinglist_id>/items/",
         StockShoppingListItemListView.as_view(),
         name="shoppinglist_items",
     ),
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/shopping_list/(?P<shoppinglist_id>[0-9]+)/delete$",
+    path(
+        "<int:stock_id>/shopping_list/<int:shoppinglist_id>/delete/",
         StockShoppingListDeleteView.as_view(),
         name="shoppinglist_delete",
     ),
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/shopping_list/(?P<shoppinglist_id>[0-9]+)/set_done$",
+    path(
+        "<int:stock_id>/shopping_list/<int:shoppinglist_id>/set_done/",
         StockShopppingListSetDone.as_view(),
         name="shoppinglist_set_done",
     ),
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/shopping_list/(?P<shoppinglist_id>[0-9]+)/set_todo$",
+    path(
+        "<int:stock_id>/shopping_list/<int:shoppinglist_id>/set_todo/",
         StockShopppingListSetTodo.as_view(),
         name="shoppinglist_set_todo",
     ),
-    re_path(
-        r"^(?P<stock_id>[0-9]+)/shopping_list/(?P<shoppinglist_id>[0-9]+)/update_stock$",
+    path(
+        "<int:stock_id>/shopping_list/<int:shoppinglist_id>/update_stock/",
         StockUpdateAfterShopppingBaseFormView.as_view(),
         name="update_after_shopping",
     ),

--- a/subscription/urls.py
+++ b/subscription/urls.py
@@ -22,12 +22,12 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from subscription.views import *
 
 urlpatterns = [
     # Subscription views
-    re_path(r"^$", NewSubscription.as_view(), name="subscription"),
-    re_path(r"stats", SubscriptionsStatsView.as_view(), name="stats"),
+    path("", NewSubscription.as_view(), name="subscription"),
+    path("stats/", SubscriptionsStatsView.as_view(), name="stats"),
 ]

--- a/trombi/urls.py
+++ b/trombi/urls.py
@@ -23,67 +23,65 @@
 #
 #
 
-from django.urls import re_path
+from django.urls import path
 
 from trombi.views import *
 
 urlpatterns = [
-    re_path(r"^(?P<club_id>[0-9]+)/new$", TrombiCreateView.as_view(), name="create"),
-    re_path(
-        r"^(?P<trombi_id>[0-9]+)/export$", TrombiExportView.as_view(), name="export"
-    ),
-    re_path(r"^(?P<trombi_id>[0-9]+)/edit$", TrombiEditView.as_view(), name="edit"),
-    re_path(
-        r"^(?P<trombi_id>[0-9]+)/moderate_comments$",
+    path("<int:club_id>/new/", TrombiCreateView.as_view(), name="create"),
+    path("<int:trombi_id>/export/", TrombiExportView.as_view(), name="export"),
+    path("<int:trombi_id>/edit/", TrombiEditView.as_view(), name="edit"),
+    path(
+        "<int:trombi_id>/moderate_comments/",
         TrombiModerateCommentsView.as_view(),
         name="moderate_comments",
     ),
-    re_path(
-        r"^(?P<comment_id>[0-9]+)/moderate$",
+    path(
+        "<int:comment_id>/moderate/",
         TrombiModerateCommentView.as_view(),
         name="moderate_comment",
     ),
-    re_path(
-        r"^user/(?P<user_id>[0-9]+)/delete$",
+    path(
+        "user/<int:user_id>/delete/",
         TrombiDeleteUserView.as_view(),
         name="delete_user",
     ),
-    re_path(r"^(?P<trombi_id>[0-9]+)$", TrombiDetailView.as_view(), name="detail"),
-    re_path(
-        r"^(?P<user_id>[0-9]+)/new_comment$",
+    path("<int:trombi_id>/", TrombiDetailView.as_view(), name="detail"),
+    path(
+        "<int:user_id>/new_comment/",
         TrombiCommentCreateView.as_view(),
         name="new_comment",
     ),
-    re_path(
-        r"^(?P<user_id>[0-9]+)/profile$",
+    path(
+        "<int:user_id>/profile/",
         UserTrombiProfileView.as_view(),
         name="user_profile",
     ),
-    re_path(
-        r"^comment/(?P<comment_id>[0-9]+)/edit$",
+    path(
+        "comment/<int:comment_id>/edit/",
         TrombiCommentEditView.as_view(),
         name="edit_comment",
     ),
-    re_path(r"^tools$", UserTrombiToolsView.as_view(), name="user_tools"),
-    re_path(r"^profile$", UserTrombiEditProfileView.as_view(), name="profile"),
-    re_path(r"^pictures$", UserTrombiEditPicturesView.as_view(), name="pictures"),
-    re_path(
-        r"^reset_memberships$",
+    path("tools/", UserTrombiToolsView.as_view(), name="user_tools"),
+    path("profile/", UserTrombiEditProfileView.as_view(), name="profile"),
+    path("pictures/", UserTrombiEditPicturesView.as_view(), name="pictures"),
+    path(
+        "reset_memberships/",
         UserTrombiResetClubMembershipsView.as_view(),
         name="reset_memberships",
     ),
-    re_path(
-        r"^membership/(?P<membership_id>[0-9]+)/edit$",
+    path(
+        "membership/<int:membership_id>/edit/",
         UserTrombiEditMembershipView.as_view(),
         name="edit_membership",
     ),
-    re_path(
-        r"^membership/(?P<membership_id>[0-9]+)/delete$",
+    path(
+        "membership/<int:membership_id>/delete/",
         UserTrombiDeleteMembershipView.as_view(),
         name="delete_membership",
     ),
-    re_path(
-        r"^membership/(?P<user_id>[0-9]+)/create$",
+    path(
+        "membership/<int:user_id>/create/",
         UserTrombiAddMembershipView.as_view(),
         name="create_membership",
     ),


### PR DESCRIPTION
Changement des urls pour utiliser `path` au lieu de `re_path`. [Voir la doc](https://docs.djangoproject.com/en/3.2/topics/http/urls/)
`path` a l'avantage de permettre des urls plus lisibles.

Pour les cas particuliers, des convertisseurs remplacent les regex dans l'url.

D'un point de vue purement fonctionnel, ça devrait résoudre le problème des pages qui peuvent 404 selon qu'on met un `/` à la fin de l'URL ou non (par exemple, actuellement, `https://ae.utbm.fr/counter/2` marche, mais `https://ae.utbm.fr/counter/2/` est 404)