### PR TITLE
resolved importError

### DIFF
--- a/counter/models.py
+++ b/counter/models.py
@@ -25,9 +25,8 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from __future__ import annotations
 from django.db import models
-from django.db.models import OuterRef, Exists, QuerySet
+from django.db.models import OuterRef, Exists
 from django.db.models.functions import Length
 from django.utils.translation import gettext_lazy as _
 from django.utils import timezone


### PR DESCRIPTION
Il semblerait qu'il y ait eu une confusion dans l'ordre des imports qui est complètement passée sous le radar de github pendant la CI de la PR mais qui a fait échouer la CI du taiste.