### PR TITLE
[PARTENARIAT] Ajout vitrine d'achat billets eurockéennes 2023

### DIFF
--- a/eboutic/templates/eboutic/eboutic_main.jinja
+++ b/eboutic/templates/eboutic/eboutic_main.jinja
@@ -124,7 +124,7 @@
                 <p>{% trans %}There are no items available for sale{% endtrans %}</p>
             {% endfor %}
 
-            <h3>{% trans %}Partnership Eurockéenes 2023{% endtrans %}</h3>
+            <h3>{% trans %}Partnership Eurockéennes 2023{% endtrans %}</h3>
             {% if user.is_subscribed %}
                 <a title="Logiciel billetterie en ligne"
                     href="https://widget.weezevent.com/ticket/a203b986-73b0-4e63-b18a-b7c8bad986b7?id_evenement=915745&locale=fr-FR&code=71348"
@@ -134,7 +134,7 @@
                     data-noscroll="0" data-id="915745">Billetterie Weezevent</a>
                 <script type="text/javascript" src="https://widget.weezevent.com/weez.js" async defer></script>
             {% else %}
-                <div>{% trans %}You must be a contributor to access the Eurockéenes ticketing service.{% endtrans %}</div>
+                <div>{% trans %}You must be a contributor to access the Eurockéennes ticketing service.{% endtrans %}</div>
             {% endif %}
         </div>
     </div>

--- a/eboutic/templates/eboutic/eboutic_main.jinja
+++ b/eboutic/templates/eboutic/eboutic_main.jinja
@@ -123,6 +123,19 @@
             {% else %}
                 <p>{% trans %}There are no items available for sale{% endtrans %}</p>
             {% endfor %}
+
+            <h3>{% trans %}Partnership Eurockéenes 2023{% endtrans %}</h3>
+            {% if user.is_subscribed %}
+                <a title="Logiciel billetterie en ligne"
+                    href="https://widget.weezevent.com/ticket/a203b986-73b0-4e63-b18a-b7c8bad986b7?id_evenement=915745&locale=fr-FR&code=71348"
+                    class="weezevent-widget-integration" target="_blank"
+                    data-src="https://widget.weezevent.com/ticket/a203b986-73b0-4e63-b18a-b7c8bad986b7?id_evenement=915745&locale=fr-FR&code=71348"
+                    data-width="650" data-height="600" data-resize="1" data-nopb="0" data-type="neo" data-width_auto="1"
+                    data-noscroll="0" data-id="915745">Billetterie Weezevent</a>
+                <script type="text/javascript" src="https://widget.weezevent.com/weez.js" async defer></script>
+            {% else %}
+                <div>{% trans %}You must be a contributor to access the Eurockéenes ticketing service.{% endtrans %}</div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6325,3 +6325,11 @@ msgstr "Vous ne pouvez plus écrire de commentaires, la date est passée."
 #, python-format
 msgid "Maximum characters: %(max_length)s"
 msgstr "Nombre de caractères max: %(max_length)s"
+
+#: eboutic/templates/eboutic/eboutic_main.jinja:127
+msgid "Partnership Eurockéenes 2023"
+msgstr "Partenariat Eurockéenes 2023"
+
+#: eboutic/templates/eboutic/eboutic_main.jinja:137
+msgid "You must be a contributor to access the Eurockéenes ticketing service."
+msgstr "Vous devez être cotisant pour pouvoir accéder à la billetterie des Eurockéenes."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6327,9 +6327,9 @@ msgid "Maximum characters: %(max_length)s"
 msgstr "Nombre de caractères max: %(max_length)s"
 
 #: eboutic/templates/eboutic/eboutic_main.jinja:127
-msgid "Partnership Eurockéenes 2023"
-msgstr "Partenariat Eurockéenes 2023"
+msgid "Partnership Eurockéennes 2023"
+msgstr "Partenariat Eurockéennes 2023"
 
 #: eboutic/templates/eboutic/eboutic_main.jinja:137
-msgid "You must be a contributor to access the Eurockéenes ticketing service."
-msgstr "Vous devez être cotisant pour pouvoir accéder à la billetterie des Eurockéenes."
+msgid "You must be a contributor to access the Eurockéennes ticketing service."
+msgstr "Vous devez être cotisant pour pouvoir accéder à la billetterie des Eurockéennes."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6331,5 +6331,5 @@ msgid "Partnership Eurockéennes 2023"
 msgstr "Partenariat Eurockéennes 2023"
 
 #: eboutic/templates/eboutic/eboutic_main.jinja:137
-msgid "You must be a contributor to access the Eurockéennes ticketing service."
+msgid "You must be a subscriber to access the Eurockéennes ticketing service."
 msgstr "Vous devez être cotisant pour pouvoir accéder à la billetterie des Eurockéennes."


### PR DESCRIPTION
Le partenariat avec les eurockéenes de cette année requiert l'implémentation de leurs billetterie au sein de l'eboutique

<details>
<summary>Screens</summary>

# Pas cotisant

![image](https://user-images.githubusercontent.com/49886317/223818024-f4a0b8da-549c-4d68-a19c-c650415e0f2f.png)

# Cotisant
![image](https://user-images.githubusercontent.com/49886317/223818109-6a601e81-d816-4d6a-bed5-479d5d224ba6.png)

</details>

> En attente de validation de la part de Thibault Chausson (respo partenariat)
> A merge dès la validation
