### PR TITLE
[ENHANCEMENT] Ajout Google Calendar des clubs & GA

### DIFF
--- a/com/templates/com/news_list.jinja
+++ b/com/templates/com/news_list.jinja
@@ -8,13 +8,13 @@
 {% block content %}
 {% if user.is_in_group(settings.SITH_GROUP_COM_ADMIN_ID) %}
 <div id="news_admin">
-  <a href="{{ url('com:news_admin_list') }}">{% trans %}Administrate news{% endtrans %}</a>
+  <a class="button" href="{{ url('com:news_admin_list') }}">{% trans %}Administrate news{% endtrans %}</a>
 </div>
+<br>
 {% endif  %}
 
 <div id="news">
     <div id="left_column" class="news_column">
-
         {% for news in object_list.filter(type="NOTICE") %}
             <section class="news_notice">
                 <h4><a href="{{ url('com:news_detail', news_id=news.id) }}">{{ news.title }}</a></h4>
@@ -97,6 +97,15 @@
                 </section>
             {% endfor %}
         {% endif %}
+
+        <h3>{% trans %}All coming events{% endtrans %}</h3>
+        <iframe 
+            src="https://embed.styledcalendar.com/#2mF2is8CEXhr4ADcX6qN" 
+            title="Styled Calendar"
+            class="styled-calendar-container" 
+            style="width: 100%; border: none; height: 1060px" 
+            data-cy="calendar-embed-iframe">
+        </iframe>
     </div>
 
     <div id="right_column" class="news_column">

--- a/core/static/core/header.scss
+++ b/core/static/core/header.scss
@@ -23,6 +23,10 @@
     flex-direction: row;
     gap: 10px;
 
+    > a {
+      color: #fff;
+    }
+
     &:hover > a {
       color: #1a78b3;
     }

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -48,6 +48,7 @@ body {
   font-family: sans-serif;
 }
 
+a.button,
 button,
 input[type="button"],
 input[type="submit"],
@@ -60,11 +61,13 @@ input[type="file"] {
   margin: 0.1em;
   font-size: 1.2em;
   border-radius: 5px;
+  color: black;
   &:hover {
     background: hsl(0, 0%, 83%);
   }
 }
 
+a.button,
 input[type="button"],
 input[type="submit"],
 input[type="reset"],
@@ -72,6 +75,7 @@ input[type="file"] {
   font-weight: bold;
 }
 
+a.button:not(:disabled),
 button:not(:disabled),
 input[type="button"]:not(:disabled),
 input[type="submit"]:not(:disabled),
@@ -111,7 +115,8 @@ select {
   border-radius: 5px;
   cursor: pointer;
 }
-a {
+
+a:not(.button) {
   text-decoration: none;
   color: $primary-dark-color;
   &:hover {
@@ -348,7 +353,11 @@ a {
   /*---------------------------------NEWS--------------------------------*/
   #news {
     display: flex;
-    flex-wrap: wrap;
+
+    @media (max-width: 800px) {
+      flex-direction: column;
+    }
+    
     .news_column {
       display: inline-block;
       margin: 0;
@@ -1403,7 +1412,7 @@ footer {
       padding: 0.8em;
       flex: 1;
       font-weight: bold;
-      color: $white-color;
+      color: $white-color !important;
       &:hover {
         color: $primary-dark-color;
       }

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -979,7 +979,7 @@ blockquote h5:first-child {
 }
 
 table {
-  width: 90%;
+  width: 100%;
   margin: 15px auto;
   border-collapse: collapse;
   border-spacing: 0;

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1713,6 +1713,10 @@ msgstr "Administrer les news"
 msgid "Events today and the next few days"
 msgstr "Événements aujourd'hui et dans les prochains jours"
 
+#: com/templates/com/news_list.jinja:100
+msgid "All coming events"
+msgstr "Tous les événements à venir"
+
 #: com/templates/com/news_list.jinja:82
 msgid "Nothing to come..."
 msgstr "Rien à venir..."


### PR DESCRIPTION
*Demande directe du bureau*

> C'est une simple `iframe` du calendrier google, j'ai utilisé le site Styled Calendar pour l'adapter aux couleurs du site & ils ont une version responsive qu'est pas mal (celui de base de google est vraiment moche)

<img width="1470" alt="Capture d’écran 2023-04-03 à 15 04 48" src="https://user-images.githubusercontent.com/49886317/229518232-27a0eb80-08ea-4e45-a88a-87a84fdf0fce.png">
