### PR TITLE
[FIX] Correction de bugs

### DIFF
--- a/club/models.py
+++ b/club/models.py
@@ -127,12 +127,22 @@ class Club(models.Model):
     def clean(self):
         self.check_loop()
 
-    def _change_unixname(self, new_name):
+    def _change_unixname(self, old_name, new_name):
         c = Club.objects.filter(unix_name=new_name).first()
         if c is None:
+            # Update all the groups names
+            Group.objects.filter(name=old_name).update(name=new_name)
+            Group.objects.filter(name=old_name + settings.SITH_BOARD_SUFFIX).update(
+                name=new_name + settings.SITH_BOARD_SUFFIX
+            )
+            Group.objects.filter(name=old_name + settings.SITH_MEMBER_SUFFIX).update(
+                name=new_name + settings.SITH_MEMBER_SUFFIX
+            )
+
             if self.home:
                 self.home.name = new_name
                 self.home.save()
+
         else:
             raise ValidationError(_("A club with that unix_name already exists"))
 

--- a/core/models.py
+++ b/core/models.py
@@ -919,7 +919,7 @@ class SithFile(models.Model):
     class Meta:
         verbose_name = _("file")
 
-    def can_be_managed_by(self, user) -> bool:
+    def can_be_managed_by(self, user: User) -> bool:
         """
         Tell if the user can manage the file (edit, delete, etc.) or not.
         Apply the following rules:
@@ -943,7 +943,9 @@ class SithFile(models.Model):
             return True
 
         # If the file is in the profiles directory, only the roots can manage it
-        if profiles_dir in self.get_parent_list() and user.is_root:
+        if profiles_dir in self.get_parent_list() and (
+            user.is_root or user.is_board_member
+        ):
             return True
 
         return False

--- a/core/models.py
+++ b/core/models.py
@@ -1159,12 +1159,6 @@ class SithFile(models.Model):
 
         return Album.objects.filter(id=self.id).first()
 
-    def __str__(self):
-        if self.is_folder:
-            return _("Folder: ") + self.name
-        else:
-            return _("File: ") + self.name
-
     def get_parent_list(self):
         l = []
         p = self.parent

--- a/core/models.py
+++ b/core/models.py
@@ -927,8 +927,7 @@ class SithFile(models.Model):
             - If the file is in the SAS, only the SAS admins (or roots) can manage it -> return True if the user is in the SAS admin group or is a root
             - If the file is in the profiles directory, only the roots can manage it -> return True if the user is a root
 
-        Returns:
-            bool: True if the file is managed by the SAS or within the profiles directory, False otherwise
+        :returns: True if the file is managed by the SAS or within the profiles directory, False otherwise
         """
 
         # If the file is not in the SAS nor in the profiles directory, it can be "managed" by anyone

--- a/core/models.py
+++ b/core/models.py
@@ -1025,7 +1025,7 @@ class SithFile(models.Model):
 
     def save(self, *args, **kwargs):
         sas = SithFile.objects.filter(id=settings.SITH_SAS_ROOT_DIR_ID).first()
-        self.is_in_sas = sas in self.get_parent_list()
+        self.is_in_sas = sas in self.get_parent_list() or self == sas
         copy_rights = False
         if self.id is None:
             copy_rights = True

--- a/core/static/core/navbar.scss
+++ b/core/static/core/navbar.scss
@@ -130,5 +130,67 @@ nav.navbar {
         }
       }
     }
-  }
+
+    > .menu > .head,
+    > .link {
+      color: white;
+      padding: 10px 20px;
+      box-sizing: border-box;
+
+      @media (max-width: 500px) {
+        padding: 10px;
+      }
+    }
+
+    .link:hover,
+    .menu:hover {
+      background-color: rgba(0, 0, 0, .2);
+    }
+
+    > .menu:hover > .content,
+    > .menu > .head:hover + .content,
+    > .menu > .content:hover {
+      display: flex;
+    }
+
+    > .menu {
+      display: flex;
+      position: relative;
+
+      > .content {
+        z-index: 10;
+        display: none;
+        position: absolute;
+        top: 100%;
+        background-color: white;
+        margin: 0;
+        list-style-type: none;
+        width: 130px;
+        box-shadow: 3px 3px 3px 0 #dfdfdf;
+        flex-direction: column;
+
+        @media (max-width: 500px) {
+          position: absolute;
+          flex-direction: row;
+          flex-wrap: wrap;
+          width: 100%;
+          box-shadow: inset 3px 3px 3px 0 #dfdfdf;
+        }
+
+        > li > a {
+          display: flex;
+          padding: 15px 20px;
+
+          @media (max-width: 500px) {
+            padding: 10px;
+          }
+
+          &:hover {
+            color: hsl(203, 75%, 40%);
+            background-color: rgba(0, 0, 0, .05);
+          }
+        }
+      }
+    }
+  }  
 }

--- a/core/templates/core/user_pictures.jinja
+++ b/core/templates/core/user_pictures.jinja
@@ -13,7 +13,7 @@
     {% if can_edit(profile, user) %}
         <button id="download_all_pictures", onclick=download_pictures()>{% trans %}Download all my pictures{% endtrans %}</button>
     {% endif %}
-    {% for a in albums | unique %}
+    {% for a in albums %}
         <h4>{{ a.name }}</h4>
         <div class="photos">
             {% for p in pictures[a.id] %}

--- a/core/templates/core/user_pictures.jinja
+++ b/core/templates/core/user_pictures.jinja
@@ -13,7 +13,7 @@
     {% if can_edit(profile, user) %}
         <button id="download_all_pictures", onclick=download_pictures()>{% trans %}Download all my pictures{% endtrans %}</button>
     {% endif %}
-    {% for a in albums %}
+    {% for a in albums | unique %}
         <h4>{{ a.name }}</h4>
         <div class="photos">
             {% for p in pictures[a.id] %}

--- a/core/utils.py
+++ b/core/utils.py
@@ -36,12 +36,11 @@ def get_git_revision_short_hash() -> str:
     Return the short hash of the current commit
     """
     try:
-        return (
-            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
-            .decode("ascii")
-            .strip()
-        )
-    except:
+        output = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+        if isinstance(output, bytes):
+            return output.decode("ascii").strip()
+        return output.strip()
+    except subprocess.CalledProcessError:
         return ""
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -35,11 +35,14 @@ def get_git_revision_short_hash() -> str:
     """
     Return the short hash of the current commit
     """
-    return (
-        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
-        .decode("ascii")
-        .strip()
-    )
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+            .decode("ascii")
+            .strip()
+        )
+    except:
+        return ""
 
 
 def get_start_of_semester(d=date.today()):

--- a/core/views/files.py
+++ b/core/views/files.py
@@ -26,7 +26,6 @@ from django.utils.translation import gettext_lazy as _
 from django.http import Http404, HttpResponse
 from wsgiref.util import FileWrapper
 from django.urls import reverse
-from django.core.exceptions import PermissionDenied
 from django import forms
 
 import os
@@ -60,7 +59,7 @@ def send_file(request, file_id, file_class=SithFile, file_attr="file"):
             ).exists()
         )
     ):
-        raise PermissionDenied
+        return forbidden(request, _("You are not allowed to view this file"))
     name = f.__getattribute__(file_attr).name
     filepath = os.path.join(settings.MEDIA_ROOT, name)
 

--- a/core/views/files.py
+++ b/core/views/files.py
@@ -26,6 +26,7 @@ from django.utils.translation import gettext_lazy as _
 from django.http import HttpResponse
 from wsgiref.util import FileWrapper
 from django.urls import reverse
+from django.core.exceptions import PermissionDenied
 from django import forms
 
 import os
@@ -38,7 +39,6 @@ from core.views import (
     CanEditMixin,
     CanEditPropMixin,
     can_view,
-    forbidden,
     not_found,
 )
 from counter.models import Counter
@@ -61,7 +61,7 @@ def send_file(request, file_id, file_class=SithFile, file_attr="file"):
             ).exists()
         )
     ):
-        return forbidden(request, _("You are not allowed to view this file"))
+        raise PermissionDenied
     name = f.__getattribute__(file_attr).name
     filepath = os.path.join(settings.MEDIA_ROOT, name)
 

--- a/core/views/files.py
+++ b/core/views/files.py
@@ -23,7 +23,7 @@ from django.views.generic.detail import SingleObjectMixin
 from django.forms.models import modelform_factory
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from wsgiref.util import FileWrapper
 from django.urls import reverse
 from django.core.exceptions import PermissionDenied
@@ -39,7 +39,6 @@ from core.views import (
     CanEditMixin,
     CanEditPropMixin,
     can_view,
-    not_found,
 )
 from counter.models import Counter
 
@@ -67,7 +66,7 @@ def send_file(request, file_id, file_class=SithFile, file_attr="file"):
 
     # check if file exists on disk
     if not os.path.exists(filepath.encode("utf-8")):
-        return not_found(request, _("File not found"))
+        raise Http404()
 
     with open(filepath.encode("utf-8"), "rb") as filename:
         wrapper = FileWrapper(filename)

--- a/core/views/files.py
+++ b/core/views/files.py
@@ -163,6 +163,13 @@ class FileEditView(CanEditMixin, UpdateView):
     template_name = "core/file_edit.jinja"
     context_object_name = "file"
 
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if not self.object.can_be_managed_by(request.user):
+            raise PermissionDenied
+
+        return super(FileEditView, self).get(request, *args, **kwargs)
+
     def get_form_class(self):
         fields = ["name", "is_moderated"]
         if self.object.is_file:
@@ -207,6 +214,13 @@ class FileEditPropView(CanEditPropMixin, UpdateView):
     template_name = "core/file_edit.jinja"
     context_object_name = "file"
     form_class = FileEditPropForm
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if not self.object.can_be_managed_by(request.user):
+            raise PermissionDenied
+
+        return super(FileEditPropView, self).get(request, *args, **kwargs)
 
     def get_form(self, form_class=None):
         form = super(FileEditPropView, self).get_form(form_class)
@@ -280,6 +294,9 @@ class FileView(CanViewMixin, DetailView, FormMixin):
 
     def get(self, request, *args, **kwargs):
         self.form = self.get_form()
+        if not self.object.can_be_managed_by(request.user):
+            raise PermissionDenied
+
         if "clipboard" not in request.session.keys():
             request.session["clipboard"] = []
         return super(FileView, self).get(request, *args, **kwargs)
@@ -326,6 +343,13 @@ class FileDeleteView(CanEditPropMixin, DeleteView):
     pk_url_kwarg = "file_id"
     template_name = "core/file_delete_confirm.jinja"
     context_object_name = "file"
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if not self.object.can_be_managed_by(request.user):
+            raise PermissionDenied
+
+        return super(FileDeleteView, self).get(request, *args, **kwargs)
 
     def get_success_url(self):
         self.object.file.delete()  # Doing it here or overloading delete() is the same, so let's do it here

--- a/core/views/files.py
+++ b/core/views/files.py
@@ -26,6 +26,7 @@ from django.utils.translation import gettext_lazy as _
 from django.http import Http404, HttpResponse
 from wsgiref.util import FileWrapper
 from django.urls import reverse
+from django.core.exceptions import PermissionDenied
 from django import forms
 
 import os
@@ -59,7 +60,7 @@ def send_file(request, file_id, file_class=SithFile, file_attr="file"):
             ).exists()
         )
     ):
-        return forbidden(request, _("You are not allowed to view this file"))
+        raise PermissionDenied
     name = f.__getattribute__(file_attr).name
     filepath = os.path.join(settings.MEDIA_ROOT, name)
 

--- a/core/views/page.py
+++ b/core/views/page.py
@@ -82,6 +82,11 @@ class PageRevView(CanViewMixin, DetailView):
 
     def dispatch(self, request, *args, **kwargs):
         res = super(PageRevView, self).dispatch(request, *args, **kwargs)
+        self.object = self.get_object()
+
+        if self.object is None:
+            return redirect("core:page_create", page_name=self.kwargs["page_name"])
+
         if self.object.need_club_redirection:
             return redirect(
                 "club:club_view_rev", club_id=self.object.club.id, rev_id=kwargs["rev"]

--- a/core/views/site.py
+++ b/core/views/site.py
@@ -52,11 +52,15 @@ class NotificationList(ListView):
     template_name = "core/notification_list.jinja"
 
     def get_queryset(self):
+        if self.request.user.is_anonymous:
+            return []
+
         # TODO: Bulk update in django 2.2
         if "see_all" in self.request.GET.keys():
             for n in self.request.user.notifications.filter(viewed=False):
                 n.viewed = True
                 n.save()
+
         return self.request.user.notifications.order_by("-date")[:20]
 
 

--- a/core/views/site.py
+++ b/core/views/site.py
@@ -31,6 +31,7 @@ from django.utils import html
 from django.views.generic import ListView, TemplateView
 from django.conf import settings
 from django.utils.text import slugify
+from django.db.models.query import QuerySet
 
 import json
 
@@ -51,10 +52,9 @@ class NotificationList(ListView):
     model = Notification
     template_name = "core/notification_list.jinja"
 
-    def get_queryset(self):
+    def get_queryset(self) -> QuerySet[Notification]:
         if self.request.user.is_anonymous:
-            return []
-
+            return Notification.objects.none()
         # TODO: Bulk update in django 2.2
         if "see_all" in self.request.GET.keys():
             for n in self.request.user.notifications.filter(viewed=False):

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -321,7 +321,7 @@ class UserPicturesView(UserTabsMixin, CanViewMixin, DetailView):
         last_album = None
         for picture in picture_qs:
             album = picture.parent
-            if album.id != last_album:
+            if album.id != last_album and album not in kwargs["albums"]:
                 kwargs["albums"].append(album)
                 kwargs["pictures"][album.id] = []
                 last_album = album.id

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -719,8 +719,12 @@ class UserPreferencesView(UserTabsMixin, CanEditMixin, UpdateView):
 
     def get_context_data(self, **kwargs):
         kwargs = super(UserPreferencesView, self).get_context_data(**kwargs)
-        if not hasattr(self.object, "trombi_user"):
+
+        if not (
+            hasattr(self.object, "trombi_user") and self.request.user.trombi_user.trombi
+        ):
             kwargs["trombi_form"] = UserTrombiForm()
+
         if hasattr(self.object, "customer"):
             kwargs["student_card_form"] = StudentCardForm()
         return kwargs

--- a/counter/views.py
+++ b/counter/views.py
@@ -583,7 +583,7 @@ class CounterClick(CounterTabsMixin, CanViewMixin, DetailView):
             - <str>, where the string is the code of the product
             - <int>X<str>, where the integer is the quantity and str the code
         """
-        string = parse_qs(request.body.decode())["code"][0].upper()
+        string = parse_qs(request.body.decode()).get("code", [""])[0].upper()
         if string == "FIN":
             return self.finish(request)
         elif string == "ANN":

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -5573,7 +5573,7 @@ msgid "German"
 msgstr "Allemant"
 
 #: sith/settings.py:449
-msgid "Spanich"
+msgid "Spanish"
 msgstr "Espagnol"
 
 #: sith/settings.py:453

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -2519,6 +2519,14 @@ msgstr "Laverie"
 msgid "Files"
 msgstr "Fichiers"
 
+#: core/views/files.py:70
+msgid "File not found"
+msgstr "Fichier introuvable"
+
+#: core/views/files.py:64
+msgid "You are not allowed to view this file"
+msgstr "Vous n'êtes pas autorisé à voir ce fichier"
+
 #: core/templates/core/base.jinja:202 core/templates/core/user_tools.jinja:109
 msgid "Pedagogy"
 msgstr "Pédagogie"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -2523,10 +2523,6 @@ msgstr "Fichiers"
 msgid "File not found"
 msgstr "Fichier introuvable"
 
-#: core/views/files.py:64
-msgid "You are not allowed to view this file"
-msgstr "Vous n'êtes pas autorisé à voir ce fichier"
-
 #: core/templates/core/base.jinja:202 core/templates/core/user_tools.jinja:109
 msgid "Pedagogy"
 msgstr "Pédagogie"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -2519,10 +2519,6 @@ msgstr "Laverie"
 msgid "Files"
 msgstr "Fichiers"
 
-#: core/views/files.py:70
-msgid "File not found"
-msgstr "Fichier introuvable"
-
 #: core/templates/core/base.jinja:202 core/templates/core/user_tools.jinja:109
 msgid "Pedagogy"
 msgstr "Pédagogie"

--- a/pedagogy/views.py
+++ b/pedagogy/views.py
@@ -206,7 +206,9 @@ class UVListView(CanViewMixin, CanCreateUVFunctionMixin, ListView):
         except TypeError:
             return self.model.objects.none()
 
-        return queryset.filter(id__in=([o.object.id for o in qs]))
+        return queryset.filter(
+            id__in=([o.object.id for o in qs if o.object is not None])
+        )
 
 
 class UVCommentReportCreateView(CanCreateMixin, CreateView):

--- a/rootplace/tests.py
+++ b/rootplace/tests.py
@@ -144,11 +144,12 @@ class MergeUserTest(TestCase):
         self.assertTrue(self.to_keep.is_subscribed)
         # to_keep had 5 months of subscription remaining and received
         # 5 more months from to_delete, so he should be subscribed for 10 months
-        self.assertEqual(
+        self.assertAlmostEqual(
             today + timedelta(10 * 30),
             self.to_keep.subscriptions.order_by("subscription_end")
             .last()
             .subscription_end,
+            delta=timedelta(1),
         )
 
     def test_godfathers(self):

--- a/sas/templates/sas/picture.jinja
+++ b/sas/templates/sas/picture.jinja
@@ -167,8 +167,10 @@
             switch (e.keyCode) {
                 case 37:
                     $('#prev a')[0].click();
+                    break;
                 case 39:
                     $('#next a')[0].click();
+                    break;
             }
         });
     });

--- a/sith/settings.py
+++ b/sith/settings.py
@@ -452,7 +452,7 @@ SITH_PEDAGOGY_UV_LANGUAGE = [
     ("FR", _("French")),
     ("EN", _("English")),
     ("DE", _("German")),
-    ("SP", _("Spanich")),
+    ("SP", _("Spanish")),
 ]
 
 SITH_PEDAGOGY_UV_RESULT_GRADE = [

--- a/trombi/templates/trombi/detail.jinja
+++ b/trombi/templates/trombi/detail.jinja
@@ -14,8 +14,8 @@
     <hr>
     <h4>{% trans %}Add user{% endtrans %}</h4>
     <form action="" method="post">
-        {% csrf_token %}
-        {{ form.as_p() }}
+        {% csrf_token %}
+        {{ form.as_p() }}
         <input type="submit" value="{% trans %}Add{% endtrans %}" />
     </form>
     <hr>

--- a/trombi/templates/trombi/user_tools.jinja
+++ b/trombi/templates/trombi/user_tools.jinja
@@ -38,18 +38,18 @@
         </div>
         <div>{{ u.user.get_display_name() }}</div>
         {% if trombi.show_profiles %}
-        <div>
-            <a href="{{ url("trombi:user_profile", user_id=u.id) }}">{% trans %}Profile{% endtrans %}</a>
-        </div>
+            <div>
+                <a href="{{ url('trombi:user_profile', user_id=u.id) }}">{% trans %}Profile{% endtrans %}</a>
+            </div>
         {% endif %}
         <div>
             {% if can_comment %}
-            {% set comment = u.received_comments.filter(author__id=user.trombi_user.id).first() %}
-            {% if comment %}
-            <a href="{{ url("trombi:edit_comment", comment_id=comment.id) }}">{% trans %}Edit comment{% endtrans %}</a>
-            {% else %}
-            <a href="{{ url("trombi:new_comment", user_id=u.id) }}">{% trans %}Comment{% endtrans %}</a>
-            {% endif %}
+                {% set comment = u.received_comments.filter(author__id=user.trombi_user.id).first() %}
+                {% if comment %}
+                    <a href="{{ url('trombi:edit_comment', comment_id=comment.id) }}">{% trans %}Edit comment{% endtrans %}</a>
+                {% else %}
+                    <a href="{{ url('trombi:new_comment', user_id=u.id) }}">{% trans %}Comment{% endtrans %}</a>
+                {% endif %}
             {% endif %}
         </div>
     </div>

--- a/trombi/views.py
+++ b/trombi/views.py
@@ -467,7 +467,8 @@ class UserTrombiProfileView(TrombiTabsMixin, DetailView):
             raise PermissionDenied()
 
         if (
-            self.object.trombi.id != request.user.trombi_user.trombi.id
+            request.user.is_anonymous
+            or self.object.trombi.id != request.user.trombi_user.trombi.id
             or self.object.user.id == request.user.id
             or not self.object.trombi.show_profiles
         ):

--- a/trombi/views.py
+++ b/trombi/views.py
@@ -463,9 +463,11 @@ class UserTrombiProfileView(TrombiTabsMixin, DetailView):
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
 
+        if request.user.is_anonymous:
+            raise PermissionDenied()
+
         if (
-            request.user.is_anonymous
-            or self.object.trombi.id != request.user.trombi_user.trombi.id
+            self.object.trombi.id != request.user.trombi_user.trombi.id
             or self.object.user.id == request.user.id
             or not self.object.trombi.show_profiles
         ):

--- a/trombi/views.py
+++ b/trombi/views.py
@@ -467,8 +467,7 @@ class UserTrombiProfileView(TrombiTabsMixin, DetailView):
             raise PermissionDenied()
 
         if (
-            request.user.is_anonymous
-            or self.object.trombi.id != request.user.trombi_user.trombi.id
+            self.object.trombi.id != request.user.trombi_user.trombi.id
             or self.object.user.id == request.user.id
             or not self.object.trombi.show_profiles
         ):

--- a/trombi/views.py
+++ b/trombi/views.py
@@ -462,8 +462,10 @@ class UserTrombiProfileView(TrombiTabsMixin, DetailView):
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
+
         if (
-            self.object.trombi.id != request.user.trombi_user.trombi.id
+            request.user.is_anonymous
+            or self.object.trombi.id != request.user.trombi_user.trombi.id
             or self.object.user.id == request.user.id
             or not self.object.trombi.show_profiles
         ):


### PR DESCRIPTION
### Fixes
- #109
  De par le fait que l'utilisateur était propriétaire de son image de profil, il pouvait accéder aux URLs suivantes : `/file/<id>/` et `/file/<id>/[delete|prop|edit]` et ce malgré l'interdiction d'accès au dossier parent `profiles`.
Une méthode `can_be_managed_by(user)` a donc été créée et régis les droits de "management" des fichiers suivants les 3 règles suivantes :   
  - Si le fichier n'est ni dans `/sas` ou `/profiles` alors les droits d'accès de base s'appliquent (comme auparavant)
  - Si le fichier est dans `/sas`, uniquement les admins SAS & roots peuvent y accéder (car le proprio du fichier pouvait tout de même le manager sans être admin SAS ou root)
  - Si le fichier est dans `/profiles`, uniquement les utilisateurs roots & membres du bureau peuvent accéder aux urls ci-dessus.

- #600 
  Ajout des mêmes étapes de vérification que dans `trombi/views.py#335`
- #601
  `Club.objects.filter(unix_name=name).first()` peux retourner `None`, ce qui n'était pas pris en compte
- #602 
  `self.request.user` peut être de deux types différents `AbstractBaseUser | AnonymousUser` donc on regarde d'abord si l'utilisateur est anonyme avant de checker s'il a des notifications
- #604
  Même problème qu'auparavant, `request.user` qui peut être `AbstractBaseUser | AnonymousUser`.
- #607 
  La méthode `subprocess.check_output()` doit être mise dans un try catch au cas ou la commande échoue (code de retour différent de 0)
- #608
  Une erreur 500 était générée lorsqu'on essayait de télécharger un fichier qui n'existait pas / plus sur le disque. Désormais, une erreur 404 est générée et renvoi le template associé.
- #609 
  La valeur parsée pouvait ne pas contenir la clé `code`, une valeur vide par défaut a été ajoutée pour pallier au problème.
- #610 
  La boucle ne vérifiait pas si l'objet était `None` avant d'accéder à ses propriétés
- #627 
  Les groupes d'accès n'étaient pas mis à jours lorsqu'on changeait le nom unix d'un club, ce qui entraînait une erreur 500 car le site ne trouvait rien