### PR TITLE
add missing method on AnonymousUser

### DIFF
--- a/com/tests.py
+++ b/com/tests.py
@@ -164,7 +164,7 @@ class NewsTest(TestCase):
         Test that moderated news can be viewed by anyone
         and not moderated news only by com admins
         """
-        # by default a new isn't moderated
+        # by default a news isn't moderated
         self.assertTrue(self.new.can_be_viewed_by(self.com_admin))
         self.assertFalse(self.new.can_be_viewed_by(self.sli))
         self.assertFalse(self.new.can_be_viewed_by(self.anonymous))

--- a/com/tests.py
+++ b/com/tests.py
@@ -159,6 +159,33 @@ class NewsTest(TestCase):
         self.assertFalse(self.new.is_owned_by(self.anonymous))
         self.assertFalse(self.new.is_owned_by(self.sli))
 
+    def test_news_viewer(self):
+        """
+        Test that moderated news can be viewed by anyone
+        and not moderated news only by com admins
+        """
+        # by default a new isn't moderated
+        self.assertTrue(self.new.can_be_viewed_by(self.com_admin))
+        self.assertFalse(self.new.can_be_viewed_by(self.sli))
+        self.assertFalse(self.new.can_be_viewed_by(self.anonymous))
+        self.assertFalse(self.new.can_be_viewed_by(self.author))
+
+        self.new.is_moderated = True
+        self.new.save()
+        self.assertTrue(self.new.can_be_viewed_by(self.com_admin))
+        self.assertTrue(self.new.can_be_viewed_by(self.sli))
+        self.assertTrue(self.new.can_be_viewed_by(self.anonymous))
+        self.assertTrue(self.new.can_be_viewed_by(self.author))
+
+    def test_news_editor(self):
+        """
+        Test that only com admins can edit news
+        """
+        self.assertTrue(self.new.can_be_edited_by(self.com_admin))
+        self.assertFalse(self.new.can_be_edited_by(self.sli))
+        self.assertFalse(self.new.can_be_edited_by(self.anonymous))
+        self.assertFalse(self.new.can_be_edited_by(self.author))
+
 
 class WeekmailArticleTest(TestCase):
     @classmethod

--- a/core/models.py
+++ b/core/models.py
@@ -810,6 +810,10 @@ class AnonymousUser(AuthAnonymousUser):
     def can_edit(self, obj):
         return False
 
+    @property
+    def is_com_admin(self):
+        return False
+
     def can_view(self, obj):
         if (
             hasattr(obj, "view_groups")


### PR DESCRIPTION
Repair [this](https://sentry.ae.utbm.fr/organizations/ae-utbm/issues/158/?referrer=webhooks_plugin).

The `NewsListView` view calls `User.is_com_admin` for right checking. However, the `AnonymousUser` class did not have such a method. This PR adds it.

This also adds some tests to avoid regression.