### PR TITLE
Update mistune (0.8 => 3.0)

### DIFF
--- a/core/management/commands/install_xapian.sh
+++ b/core/management/commands/install_xapian.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Originates from https://gist.github.com/jorgecarleitao/ab6246c86c936b9c55fd
 # first argument of the script is Xapian version (e.g. 1.2.19)
-VERSION=$1
+VERSION="$1"
 
 # Cleanup env vars for auto discovery mechanism
 export CPATH=

--- a/core/markdown.py
+++ b/core/markdown.py
@@ -12,161 +12,125 @@
 # OR WITHIN THE LOCAL FILE "LICENSE"
 #
 #
+from __future__ import annotations
 
 import os
 import re
+from typing import TYPE_CHECKING
 
+import mistune
 from django.urls import reverse
-from mistune import InlineGrammar, InlineLexer, Markdown, Renderer, escape, escape_link
+from mistune import HTMLRenderer, Markdown
+
+if TYPE_CHECKING:
+    from mistune import InlineParser, InlineState
+
+# match __text__, without linebreak in the text, nor backslash prepending an underscore
+# Examples :
+#   - "__text__" : OK
+#   - "__te xt__" : OK
+#   - "__te_xt__" : nope (underscore in the middle)
+#   - "__te\_xt__" : Ok (the middle underscore is escaped)
+#   - "__te\nxt__" : nope (there is a linebreak in the text)
+#   - "\__text__" : nope (one of the underscores have a backslash prepended)
+#   - "\\__text__" : Ok (the backslash is ignored, because there is another backslash before)
+UNDERLINED_RE = (
+    r"(?<!\\)(?:\\{2})*"  # ignore if there is an odd number of backslashes before
+    r"_{2}"  # two underscores
+    r"(?P<underlined>([^\\_]|\\.)+)"  # the actual text
+    r"_{2}"  # closing underscores
+)
+
+SITH_LINK_RE = (
+    r"\[(?P<page_name>[\w\s]+)\]"  #  [nom du lien]
+    r"\(page:\/\/"  #  (page://
+    r"(?P<page_slug>[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9])"  # actual page name
+    r"\)"  # )
+)
+
+CUSTOM_DIMENSIONS_IMAGE_RE = (
+    r"\[(?P<img_name>[\w\s]+)\]"  # [nom du lien]
+    r"\(img:\/\/"  # (img://
+    r"(?P<img_slug>[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9])"  # actual page name
+    r"\)"  # )
+)
 
 
-class SithRenderer(Renderer):
-    def file_link(self, pk, suffix):
-        return reverse("core:file_detail", kwargs={"file_id": pk}) + suffix
-
-    def exposant(self, text):
-        return """<sup>%s</sup>""" % text
-
-    def indice(self, text):
-        return """<sub>%s</sub>""" % text
-
-    def underline(self, text):
-        return """<u>%s</u>""" % text
-
-    def image(self, original_src, title, text):
-        """Rendering a image with title and text.
-        :param src: source link of the image.
-        :param title: title text of the image.
-        :param text: alt text of the image.
-        """
-        style = None
-        if "?" in original_src:
-            src, params = original_src.rsplit("?", maxsplit=1)
-            m = re.search(r"(\d+%?)(x(\d+%?))?", params)
-            if not m:
-                src = original_src
-            else:
-                width = m.group(1)
-                if not width.endswith("%"):
-                    width += "px"
-                style = "width: %s; " % width
-                height = m.group(3)
-                if height is not None:
-                    if not height.endswith("%"):
-                        height += "px"
-                    style += "height: %s; " % height
-        else:
-            params = None
-            src = original_src
-        src = escape_link(src)
-        text = escape(text, quote=True)
-        if title:
-            title = escape(title, quote=True)
-            html = '<img src="%s" alt="%s" title="%s"' % (src, text, title)
-        else:
-            html = '<img src="%s" alt="%s"' % (src, text)
-        if style:
-            html = '%s style="%s"' % (html, style)
-        if self.options.get("use_xhtml"):
-            return "%s />" % html
-        return "%s>" % html
+def parse_underline(_inline: InlineParser, m: re.Match, state: InlineState):
+    state.append_token({"type": "underline", "raw": m.group("underlined")})
+    return m.end()
 
 
-class SithInlineGrammar(InlineGrammar):
-    double_emphasis = re.compile(r"^\*{2}([\s\S]+?)\*{2}(?!\*)")  # **word**
-    emphasis = re.compile(r"^\*((?:\*\*|[^\*])+?)\*(?!\*)")  # *word*
-    underline = re.compile(r"^_{2}([\s\S]+?)_{2}(?!_)")  # __word__
-    exposant = re.compile(r"^<sup>([\s\S]+?)</sup>")  # <sup>text</sup>
-    indice = re.compile(r"^<sub>([\s\S]+?)</sub>")  # <sub>text</sub>
-
-
-class SithInlineLexer(InlineLexer):
-    grammar_class = SithInlineGrammar
-
-    default_rules = [
-        "escape",
-        # 'inline_html',
-        "autolink",
-        "url",
-        "footnote",
-        "link",
-        "reflink",
-        "nolink",
-        "exposant",
-        "double_emphasis",
-        "emphasis",
+def underline(md_instance: Markdown):
+    md_instance.inline.register(
         "underline",
-        "indice",
-        "code",
-        "linebreak",
+        UNDERLINED_RE,
+        parse_underline,
+        before="emphasis",
+    )
+    md_instance.renderer.register("underline", lambda _, text: f"<u>{text}</u>")
+
+
+def parse_sith_link(_inline: InlineParser, m: re.Match, state: InlineState):
+    page_name = m.group("page_name")
+    page_slug = m.group("page_slug")
+    state.append_token(
+        {
+            "type": "link",
+            "children": [{"type": "text", "raw": page_name}],
+            "attrs": {"url": reverse("core:page", kwargs={"page_name": page_slug})},
+        }
+    )
+    return m.end()
+
+
+def sith_link(md_instance: Markdown):
+    md_instance.inline.register(
+        "sith_link",
+        SITH_LINK_RE,
+        parse_sith_link,
+        before="emphasis",
+    )
+    # no custom renderer here.
+    # we just add another parsing rule, but render it as if it was
+    # a regular markdown link
+
+
+class SithRenderer(HTMLRenderer):
+    def image(self, text: str, url: str, title=None) -> str:
+        if "?" not in url:
+            return super().image(text, url, title)
+
+        new_url, params = url.rsplit("?", maxsplit=1)
+        m = re.match(r"^(?P<width>\d+(%|px)?)(x(?P<height>\d+(%|px)?))?$", params)
+        if not m:
+            return super().image(text, url, title)
+
+        width, height = m.group("width"), m.group("height")
+        if not width.endswith(("%", "px")):
+            width += "px"
+        style = f"width:{width};"
+        if height is not None:
+            if not height.endswith(("%", "px")):
+                height += "px"
+            style += f"height:{height};"
+        return super().image(text, new_url, title).replace("/>", f'style="{style}" />')
+
+
+markdown = mistune.create_markdown(
+    renderer=SithRenderer(escape=True),
+    plugins=[
+        underline,
+        sith_link,
         "strikethrough",
-        "text",
-    ]
-    inline_html_rules = [
-        "escape",
-        "autolink",
+        "footnotes",
+        "table",
+        "spoiler",
+        "subscript",
+        "superscript",
         "url",
-        "link",
-        "reflink",
-        "nolink",
-        "exposant",
-        "double_emphasis",
-        "emphasis",
-        "underline",
-        "indice",
-        "code",
-        "linebreak",
-        "strikethrough",
-        "text",
-    ]
-
-    def output_underline(self, m):
-        text = m.group(1)
-        return self.renderer.underline(text)
-
-    def output_exposant(self, m):
-        text = m.group(1)
-        return self.renderer.exposant(text)
-
-    def output_indice(self, m):
-        text = m.group(1)
-        return self.renderer.indice(text)
-
-    # Double emphasis rule changed
-    def output_double_emphasis(self, m):
-        text = m.group(1)
-        text = self.output(text)
-        return self.renderer.double_emphasis(text)
-
-    # Emphasis rule changed
-    def output_emphasis(self, m):
-        text = m.group(1)
-        text = self.output(text)
-        return self.renderer.emphasis(text)
-
-    def _process_link(self, m, link, title=None):
-        try:  # Add page:// support for links
-            page = re.compile(r"^page://(\S*)")  # page://nom_de_ma_page
-            match = page.search(link)
-            page = match.group(1) or ""
-            link = reverse("core:page", kwargs={"page_name": page})
-        except:
-            pass
-        try:  # Add file:// support for links
-            file_link = re.compile(r"^file://(\d*)/?(\S*)?")  # file://4000/download
-            match = file_link.search(link)
-            pk = match.group(1)
-            suffix = match.group(2) or ""
-            link = reverse("core:file_detail", kwargs={"file_id": id}) + suffix
-        except:
-            pass
-        return super()._process_link(m, link, title)
-
-
-renderer = SithRenderer(escape=True)
-inline = SithInlineLexer(renderer)
-
-markdown = Markdown(renderer, inline=inline)
+    ],
+)
 
 if __name__ == "__main__":
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/core/static/core/markdown.scss
+++ b/core/static/core/markdown.scss
@@ -1,0 +1,75 @@
+.markdown {
+  --bg-lightgrey: rgb(240, 241, 245);
+  --border-lightgrey: rgb(215, 216, 220);
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    padding-top: 20px;
+  }
+
+  ul,
+  ol,
+  p {
+    line-height: 22px;
+  }
+
+  code {
+    overflow: auto;
+    max-width: 100%;
+    font-family: Consolas;
+    font-size: 14px;
+    border-radius: 4px;
+    border: 1px solid var(--border-lightgrey);
+    background-color: var(--bg-lightgrey);
+    padding: 1px 2px;
+  }
+
+  pre code {
+    // code that is not inlined
+    margin: 15px;
+    padding: 10px;
+    display: block;
+    border-radius: 5px;
+    font-size: 1em;
+
+    @media screen and (max-width: 500px) {
+      margin: 10px 0;
+    }
+  }
+
+  blockquote {
+    background-color: var(--bg-lightgrey);
+    border: unset;
+    border-left: 5px solid #ccc;
+    border-radius: 4px;
+    margin: 15px;
+    padding: 10px 15px;
+    display: block;
+    width: fit-content;
+
+    p:first-of-type {
+      margin-top: 0;
+    }
+
+    @media screen and (max-width: 500px) {
+      margin: 10px 0;
+      padding: 8px 10px;
+    }
+  }
+
+  table {
+    width: auto;
+    min-width: 30%;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+  .footnotes {
+    font-size: 85%;
+  }
+}

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -357,7 +357,7 @@ a:not(.button) {
     @media (max-width: 800px) {
       flex-direction: column;
     }
-    
+
     .news_column {
       display: inline-block;
       margin: 0;
@@ -947,22 +947,6 @@ dt {
   margin-top: 25px;
 }
 
-code {
-  font-family: monospace;
-  overflow: auto;
-  max-width: 100%;
-}
-
-blockquote {
-  margin: 5px;
-  padding: 2px;
-  border: solid 1px $black-color;
-}
-
-blockquote h5:first-child {
-  font-size: 100%;
-}
-
 .edit-bar {
   display: block;
   margin: 4px;
@@ -979,17 +963,18 @@ blockquote h5:first-child {
 }
 
 table {
-  width: 100%;
+  width: 90%;
   margin: 15px auto;
   border-collapse: collapse;
   border-spacing: 0;
   border-radius: 5px;
   -moz-border-radius: 5px;
   overflow: hidden;
-  box-shadow: rgba(60, 64, 67, .3) 0 1px 3px 0, rgba(60, 64, 67, .15) 0 4px 8px 3px;
+  box-shadow: rgba(60, 64, 67, 0.3) 0 1px 3px 0,
+    rgba(60, 64, 67, 0.15) 0 4px 8px 3px;
 }
 
-@media screen and (max-width: 500px){
+@media screen and (max-width: 500px) {
   table {
     width: 100%;
   }
@@ -999,7 +984,8 @@ th {
   padding: 4px;
 }
 
-td, th {
+td,
+th {
   vertical-align: middle;
   text-align: center;
   padding: 5px 10px;
@@ -1009,7 +995,6 @@ td, th {
 }
 
 td {
-  padding: 4px;
   margin: 5px;
   border-collapse: collapse;
   vertical-align: top;
@@ -1020,7 +1005,8 @@ td {
   }
 }
 
-th, thead td {
+th,
+thead td {
   text-align: center;
   border-top: none;
 }
@@ -1421,7 +1407,7 @@ footer {
 
   > .version {
     margin-top: 3px;
-    color: rgba(0, 0, 0, .3)
+    color: rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -1482,31 +1468,6 @@ label {
   }
   button {
     vertical-align: middle;
-  }
-}
-
-/*-------------------------------MARKDOWN------------------------------*/
-
-.markdown {
-  margin: 0;
-  padding: 0;
-  code {
-    font-family: monospace;
-    color: $white-color;
-    background: $black-color;
-    display: inline-block;
-    padding: 4px;
-    line-height: 120%;
-    vertical-align: middle;
-  }
-  a {
-    color: $primary-dark-color;
-  }
-  a:hover {
-    text-decoration: underline;
-  }
-  .footnotes {
-    font-size: 85%;
   }
 }
 

--- a/core/templates/core/base.jinja
+++ b/core/templates/core/base.jinja
@@ -9,6 +9,7 @@
             <link rel="stylesheet" href="{{ static('core/jquery.datetimepicker.min.css') }}">
             <link rel="stylesheet" href="{{ static('ajax_select/css/ajax_select.css') }}">
             <link rel="stylesheet" href="{{ scss('core/style.scss') }}">
+            <link rel="stylesheet" href="{{ scss('core/markdown.scss') }}">
             <link rel="stylesheet" href="{{ scss('core/header.scss') }}">
             <link rel="stylesheet" href="{{ scss('core/navbar.scss') }}">
 

--- a/core/templates/core/markdown_textarea.jinja
+++ b/core/templates/core/markdown_textarea.jinja
@@ -74,7 +74,7 @@
 						name: "superscript",
 						action: function customFunction(editor){
 							let cm = editor.codemirror;
-							cm.replaceSelection('<sup>' + cm.getSelection() + '</sup>');
+							cm.replaceSelection('^' + cm.getSelection() + '^');
 						},
 						className: "fa fa-superscript",
 						title: "{{ translations.superscript }}"
@@ -83,7 +83,7 @@
 						name: "subscript",
 						action: function customFunction(editor){
 							let cm = editor.codemirror;
-							cm.replaceSelection('<sub>' + cm.getSelection() + '</sub>');
+							cm.replaceSelection('~' + cm.getSelection() + '~');
 						},
 						className: "fa fa-subscript",
 						title: "{{ translations.subscript }}"

--- a/doc/SYNTAX.html
+++ b/doc/SYNTAX.html
@@ -1,29 +1,22 @@
 <p>Cette page vise à documenter la syntaxe <em>Markdown</em> utilisée sur le site.</p>
 <h1>Markdown-AE Documentation</h1>
 <p>Le Markdown le plus standard se trouve documenté ici:
-<a href="https://daringfireball.net/projects/markdown/syntax">https://daringfireball.net/projects/markdown/syntax</a> .<br>
+<a href="https://www.markdownguide.org/basic-syntax">https://www.markdownguide.org/basic-syntax</a>.<br />
 Si cette page n'est pas exhaustive vis à vis de la syntaxe du site AE,
 elle a au moins le mérite de bien documenter le Markdown original.</p>
-<p>Le réel parseur du site AE est une version tunée de <a href="https://github.com/lepture/mistune">mistune</a>.<br>
+<p>Le réel parseur du site AE est une version tunée de <a href="https://github.com/lepture/mistune">mistune</a>.<br />
 Les plus aventureux pourront aller lire ses <a href="https://github.com/lepture/mistune/blob/master/tests/fixtures">tests</a>
-afin d'en connaître la syntaxe le plus finement possible.<br>
+afin d'en connaître la syntaxe le plus finement possible.<br />
 En pratique, cette page devrait déjà résumer une bonne partie.</p>
 <h2>Basique</h2>
 <ul>
-<li><p>Mettre le texte en <strong>gras</strong> : <code>**texte**</code></p>
-</li>
-<li><p>Mettre le texte en <em>italique</em> : <code>*texte*</code></p>
-</li>
-<li><p><u>Souligner</u> le texte : <code>__texte__</code></p>
-</li>
-<li><p><del>Barrer du texte</del> : <code>~~texte~~</code></p>
-</li>
-<li><p>On peut bien sûr tout <del><strong><em><u>combiner</u></em></strong></del> : <code>~~***__texte__***~~</code></p>
-</li>
-<li><p><sup>Mettre du texte</sup> en exposant : <code>&lt;sup&gt;texte&lt;/sup&gt;</code></p>
-</li>
-<li><p><sub>Mettre du texte</sub> en indice : <code>&lt;sub&gt;texte&lt;/sub&gt;</code></p>
-</li>
+<li>Mettre le texte en <strong>gras</strong> : <code>**texte**</code></li>
+<li>Mettre le texte en <em>italique</em> : <code>*texte*</code></li>
+<li><u>Souligner</u> le texte : <code>__texte__</code></li>
+<li><del>Barrer du texte</del> : <code>~~texte~~</code></li>
+<li>On peut bien sûr tout <del><em><strong><u>combiner</u></strong></em></del> : <code>~~***__texte__***~~</code></li>
+<li>Mettre du texte^en exposant^ : <code>&lt;sup&gt;texte&lt;/sup&gt;</code></li>
+<li>Mettre du texte~en indice~ : <code>&lt;sub&gt;texte&lt;/sub&gt;</code></li>
 </ul>
 <h2>Liens</h2>
 <ul>
@@ -43,7 +36,7 @@ l'adresse complète d'une page : <code>[nom du lien](page://nomDeLaPage)</code><
 <li>On peut également utiliser une image pour les liens :
 <code>[nom du lien]![images/imageDuSiteAE.png](/chemin/vers/image.png titre optionnel)(options)</code></li>
 </ul>
-<p>[nom du lien]<img src="/chemin/vers/image.png titre optionnel" alt="images/imageDuSiteAE.png">(options)</p>
+<p>[nom du lien]![images/imageDuSiteAE.png](/chemin/vers/image.png titre optionnel)(options)</p>
 <h2>Titres</h2>
 <ul>
 <li>Plusieurs niveaux de titres sont possibles</li>
@@ -56,17 +49,12 @@ etc...
 <h1>Titre de niveau 1</h1>
 <h2>Titre de niveau 2</h2>
 <h3>Titre de niveau 3</h3>
-<p>Si le titre de votre section commence par un tilde (~) alors le texte sous la section est
-affiché par défaut caché et il est consultable grace à un bouton +/-</p>
-<h2>~Test</h2>
 <h2>Paragraphes et sauts de ligne</h2>
 <p>Un nouveau paragraphe se fait avec deux retours à la ligne.</p>
 <p>Un saut de ligne se force avec au moins deux espaces en fin de ligne.</p>
 <h2>Listes</h2>
 <p>Il est possible de créer des listes :</p>
-<ul>
-<li>ordonnées :</li>
-</ul>
+<h3>ordonnées :</h3>
 <pre><code>1. élément
 2. élément
 3. élément
@@ -86,12 +74,10 @@ affiché par défaut caché et il est consultable grace à un bouton +/-</p>
 <li>élément</li>
 <li>élément</li>
 </ol>
-<ul>
-<li>non ordonnées :</li>
-</ul>
-<pre><code> * élément
- * élément
- * élément
+<h3>non ordonnées :</h3>
+<pre><code>- élément
+- élément
+- élément
 </code></pre>
 <ul>
 <li>élément</li>
@@ -106,22 +92,23 @@ affiché par défaut caché et il est consultable grace à un bouton +/-</p>
 | test  | test   |   test |
 </code></pre>
 <table>
-<thead><tr>
-<th>Titre</th>
-<th>Titre2</th>
-<th>Titre3</th>
+<thead>
+<tr>
+  <th>Titre</th>
+  <th>Titre2</th>
+  <th>Titre3</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>test</td>
-<td>test</td>
-<td>test</td>
+  <td>test</td>
+  <td>test</td>
+  <td>test</td>
 </tr>
 <tr>
-<td>test</td>
-<td>test</td>
-<td>test</td>
+  <td>test</td>
+  <td>test</td>
+  <td>test</td>
 </tr>
 </tbody>
 </table>
@@ -131,76 +118,70 @@ affiché par défaut caché et il est consultable grace à un bouton +/-</p>
 | gauche | centre | droite |
 </code></pre>
 <table>
-<thead><tr>
-<th style="text-align:left">Titre</th>
-<th style="text-align:center">Titre2</th>
-<th style="text-align:right">Titre3</th>
+<thead>
+<tr>
+  <th style="text-align:left">Titre</th>
+  <th style="text-align:center">Titre2</th>
+  <th style="text-align:right">Titre3</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">gauche</td>
-<td style="text-align:center">centre</td>
-<td style="text-align:right">droite</td>
+  <td style="text-align:left">gauche</td>
+  <td style="text-align:center">centre</td>
+  <td style="text-align:right">droite</td>
 </tr>
 </tbody>
 </table>
 <h2>Images et contenus</h2>
-<p>Une image est insérée ainsi : <code>![texte alternatif](/chemin/vers/image.png "titre optionnel")</code>
-<img src="/static/core/img/logo.png" alt="texte alternatif" title="titre optionnel"></p>
-<p>On peut lui spécifier ses dimensions de plusieurs manières:</p>
-<pre><code>![image à 50%](/static/core/img/logo.png?50% "Image à 50%")
-![image de  350 pixels de large](/static/core/img/logo.png?350 "Image de 350 pixels")
-![image de 350x100 pixels](/static/core/img/logo.png?350x100 "Image de 350x100 pixels")
+<p>Une image est insérée ainsi : <code>![texte alternatif](/chemin/vers/image.png &quot;titre optionnel&quot;)</code>
+<img src="/static/core/img/logo.png" alt="texte alternatif" title="titre optionnel" /></p>
+<p>On peut lui spécifier ses dimensions de plusieurs manières :</p>
+<pre><code>![image à 50%](/static/core/img/logo.png?50% &quot;Image à 50%&quot;)
+![image de 350 pixels de large](/static/core/img/logo.png?350 &quot;Image de 350 pixels&quot;)
+![image de 350x100 pixels](/static/core/img/logo.png?350x100 &quot;Image de 350x100 pixels&quot;)
 </code></pre>
-<p><img src="/static/core/img/logo.png" alt="image à 50%" title="Image à 50%" style="width: 50%; "><br>
+<p><img src="/static/core/img/logo.png" alt="image à 50%" title="Image à 50%" style="width:50%;" /><br />
 Image à 50% de la largeur de la page.</p>
-<p><img src="/static/core/img/logo.png" alt="image de 350 pixels de large" title="Image de 350 pixels" style="width: 350px; "><br>
+<p><img src="/static/core/img/logo.png" alt="image de 350 pixels de large" title="Image de 350 pixels" style="width:350px;" /><br />
 Image de 350 pixels de large.</p>
-<p><img src="/static/core/img/logo.png" alt="image de 350x100 pixels" title="Image de 350x100 pixels" style="width: 350px; height: 100px; "><br>
+<p><img src="/static/core/img/logo.png" alt="image de 350x100 pixels" title="Image de 350x100 pixels" style="width:350px;height:100px;" /><br />
 Image de 350x100 pixels.</p>
-<p>( devrait pouvoir détecter si vidéo ou non )</p>
+<p>(devrait pouvoir détecter si vidéo ou non)</p>
 <h2>Blocs de citations</h2>
 <p>Un bloc de citation se crée ainsi :</p>
 <pre><code>&gt; Ceci est
 &gt; un bloc de
 &gt; citation
 </code></pre>
-<blockquote><p>Ceci est
+<blockquote>
+<p>Ceci est
 un bloc de
 citation</p>
 </blockquote>
 <p>Il est possible d'intégrer de la syntaxe Markdown-AE dans un tel bloc.</p>
 <h2>Note de bas de page</h2>
-<p>On les créer comme ça<sup class="footnote-ref" id="fnref-key"><a href="#fn-key">1</a></sup>:</p>
-<h2>échapper des caractères</h2>
+<p>On les crée comme ça<sup class="footnote-ref" id="fnref-1"><a href="#fn-1">1</a></sup>:</p>
+<pre><code>Je fais une note[^clef].
+
+[^clef]: je note ensuite où je veux le contenu de ma clef qui apparaîtra quand même en bas
+</code></pre>
+<p>Vous pouvez aussi utiliser des numéros pour nommer vos clefs.</p>
+<pre><code>Note plus complexe[^1]
+
+[^1]:
+    je peux même faire des blocs
+    sur plusieurs lignes, comme d'habitude!
+</code></pre>
+<h2>Échapper des caractères</h2>
 <ul>
 <li>Il est possible d'ignorer un caractère spécial en l'échappant à l'aide d'un \</li>
 <li>L'échappement de blocs de codes complet se fera à l'aide de balises &lt;nosyntax&gt;&lt;/nosyntax&gt;</li>
 </ul>
-<h2>Autres ( hérité de l'ancien wiki )</h2>
-<ul>
-<li>Une ligne peut être crée avec une ligne contenant 4 tirets ( - ).</li>
-<li>Une barre de progression est crée ainsi :<blockquote><p>[[[70]]]</p>
-</blockquote>
-</li>
-<li>Notes en pied de page :<blockquote><p>((note))</p>
-</blockquote>
-</li>
-</ul>
-<div class="footnotes">
-<hr>
-<ol><li id="fn-key"><p>ceci est le contenu de ma clef</p>
-<pre><code>Je fais une note[^clef].
-
-[^clef]: je note ensuite ou je veux le contenu de ma clef qui apparaîtra quand même en bas
-</code></pre>
-<p>Vous pouvez utiliser des numéros pour nommer vos clef si vous avez la flemme.</p>
-<pre><code>Note plus complexe[^1]
-
-[^1]:
-    je peux même faire des blocks   
-    sur plusieurs lignes, comme d'habitude!
-</code></pre><p><a href="#fnref-key" class="footnote">&#8617;</a></p></li>
+<h2>Autres (hérité de l'ancien wiki)</h2>
+<p>Une ligne peut être créée avec une ligne contenant 4 tirets (<code>----</code>).</p>
+<section class="footnotes">
+<ol>
+<li id="fn-1"><p>ceci est le contenu de ma clef<a href="#fnref-1" class="footnote">&#8617;</a></p></li>
 </ol>
-</div>
+</section>

--- a/doc/SYNTAX.md
+++ b/doc/SYNTAX.md
@@ -3,7 +3,7 @@ Cette page vise à documenter la syntaxe *Markdown* utilisée sur le site.
 # Markdown-AE Documentation
 
 Le Markdown le plus standard se trouve documenté ici:
-https://daringfireball.net/projects/markdown/syntax .  
+https://www.markdownguide.org/basic-syntax.  
 Si cette page n'est pas exhaustive vis à vis de la syntaxe du site AE,
 elle a au moins le mérite de bien documenter le Markdown original.
 
@@ -14,37 +14,31 @@ En pratique, cette page devrait déjà résumer une bonne partie.
 
 ## Basique
 
-* Mettre le texte en **gras** : `**texte**`
-
-* Mettre le texte en *italique* : `*texte*`
-
-* __Souligner__ le texte : `__texte__`
-
-* ~~Barrer du texte~~ : `~~texte~~`
-
-* On peut bien sûr tout ~~***__combiner__***~~ : `~~***__texte__***~~`
-
-* <sup>Mettre du texte</sup> en exposant : `<sup>texte</sup>`
-
-* <sub>Mettre du texte</sub> en indice : `<sub>texte</sub>`
+- Mettre le texte en **gras** : `**texte**`
+- Mettre le texte en *italique* : `*texte*`
+- __Souligner__ le texte : `__texte__`
+- ~~Barrer du texte~~ : `~~texte~~`
+- On peut bien sûr tout ~~***__combiner__***~~ : `~~***__texte__***~~`
+- Mettre du texte^en exposant^ : `<sup>texte</sup>`
+- Mettre du texte~en indice~ : `<sub>texte</sub>`
 
 
 ## Liens
 
-* Les liens simples sont détectés automatiquement : `http://www.site.com`
+- Les liens simples sont détectés automatiquement : `http://www.site.com`
 
 http://www.site.com
 
-* Il est possible de nommer son lien : `[nom du lien](http://www.site.com)`
+- Il est possible de nommer son lien : `[nom du lien](http://www.site.com)`
 
 [nom du lien](http://www.site.com)
 
-* Les liens peuvent être internes au site de l'AE, on peut dès lors éviter d'entrer
+- Les liens peuvent être internes au site de l'AE, on peut dès lors éviter d'entrer
 l'adresse complète d'une page : `[nom du lien](page://nomDeLaPage)`
 
 [nom du lien](page://nomDeLaPage)
 
-* On peut également utiliser une image pour les liens :
+- On peut également utiliser une image pour les liens :
 `[nom du lien]![images/imageDuSiteAE.png](/chemin/vers/image.png titre optionnel)(options)`
 
 [nom du lien]![images/imageDuSiteAE.png](/chemin/vers/image.png titre optionnel)(options)
@@ -53,7 +47,7 @@ l'adresse complète d'une page : `[nom du lien](page://nomDeLaPage)`
 
 ## Titres
 
-* Plusieurs niveaux de titres sont possibles
+- Plusieurs niveaux de titres sont possibles
 
 ```
 # Titre de niveau 1
@@ -64,11 +58,6 @@ etc...
 # Titre de niveau 1
 ## Titre de niveau 2
 ### Titre de niveau 3
-
-Si le titre de votre section commence par un tilde (~) alors le texte sous la section est
-affiché par défaut caché et il est consultable grace à un bouton +/-
-
-## ~Test
 
 ## Paragraphes et sauts de ligne
 
@@ -81,7 +70,7 @@ Un saut de ligne se force avec au moins deux espaces en fin de ligne.
 
 Il est possible de créer des listes :
 
-* ordonnées :
+### ordonnées :
 
 ```
 1. élément
@@ -104,16 +93,16 @@ Vous pouvez marquer plus simplement comme suit, les numéros se faisant tout seu
 1. élément
 
 
-* non ordonnées :
+### non ordonnées :
 
 ```
- * élément
- * élément
- * élément
+- élément
+- élément
+- élément
 ```
-* élément
-* élément
-* élément
+- élément
+- élément
+- élément
 
 
 ## Tableaux
@@ -148,11 +137,11 @@ L'alignement dans les cellules est géré comme suit, avec les ':' sur la ligne 
 Une image est insérée ainsi : `![texte alternatif](/chemin/vers/image.png "titre optionnel")`
 ![texte alternatif](/static/core/img/logo.png "titre optionnel")
 
-On peut lui spécifier ses dimensions de plusieurs manières:
+On peut lui spécifier ses dimensions de plusieurs manières :
 
 ```
 ![image à 50%](/static/core/img/logo.png?50% "Image à 50%")
-![image de  350 pixels de large](/static/core/img/logo.png?350 "Image de 350 pixels")
+![image de 350 pixels de large](/static/core/img/logo.png?350 "Image de 350 pixels")
 ![image de 350x100 pixels](/static/core/img/logo.png?350x100 "Image de 350x100 pixels")
 ```
 
@@ -166,7 +155,7 @@ Image de 350 pixels de large.
 ![image de 350x100 pixels](/static/core/img/logo.png?350x100 "Image de 350x100 pixels")   
 Image de 350x100 pixels.
 
-( devrait pouvoir détecter si vidéo ou non )
+(devrait pouvoir détecter si vidéo ou non)
 
 ## Blocs de citations
 
@@ -185,39 +174,29 @@ Il est possible d'intégrer de la syntaxe Markdown-AE dans un tel bloc.
 
 ## Note de bas de page
 
-On les créer comme ça[^key]:
+On les crée comme ça[^key]:
 
 [^key]: ceci est le contenu de ma clef
-    ```
-    Je fais une note[^clef].
+```
+Je fais une note[^clef].
 
-    [^clef]: je note ensuite ou je veux le contenu de ma clef qui apparaîtra quand même en bas
-    ```
-    Vous pouvez utiliser des numéros pour nommer vos clef si vous avez la flemme.
-    
-    ```
-    Note plus complexe[^1]
+[^clef]: je note ensuite où je veux le contenu de ma clef qui apparaîtra quand même en bas
+```
+Vous pouvez aussi utiliser des numéros pour nommer vos clefs.
 
-    [^1]:
-        je peux même faire des blocks   
-        sur plusieurs lignes, comme d'habitude!
+```
+Note plus complexe[^1]
 
-    ```
+[^1]:
+    je peux même faire des blocs
+    sur plusieurs lignes, comme d'habitude!
+```
 
-## échapper des caractères
+## Échapper des caractères
 
-* Il est possible d'ignorer un caractère spécial en l'échappant à l'aide d'un \
-* L'échappement de blocs de codes complet se fera à l'aide de balises <nosyntax></nosyntax>
+- Il est possible d'ignorer un caractère spécial en l'échappant à l'aide d'un \
+- L'échappement de blocs de codes complet se fera à l'aide de balises <nosyntax></nosyntax>
 
+## Autres (hérité de l'ancien wiki)
 
-
-## Autres ( hérité de l'ancien wiki )
-
-* Une ligne peut être crée avec une ligne contenant 4 tirets ( - ).
-* Une barre de progression est crée ainsi :
-> [[[70]]]
-* Notes en pied de page :
-> ((note))
-
-
-
+Une ligne peut être créée avec une ligne contenant 4 tirets (`----`).

--- a/poetry.lock
+++ b/poetry.lock
@@ -888,13 +888,13 @@ traitlets = "*"
 
 [[package]]
 name = "mistune"
-version = "0.8.4"
-description = "The fastest markdown parser in pure Python"
+version = "3.0.2"
+description = "A sane and fast Markdown parser with useful plugins and renderers"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"},
-    {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
+    {file = "mistune-3.0.2-py3-none-any.whl", hash = "sha256:71481854c30fdbc938963d3605b72501f5c10a9320ecd412c121c163a1c7d205"},
+    {file = "mistune-3.0.2.tar.gz", hash = "sha256:fc7f93ded930c92394ef2cb6f04a8aabab4117a91449e72dcc8dfa646a508be8"},
 ]
 
 [[package]]
@@ -1865,5 +1865,5 @@ filelock = ">=3.4"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10,<3.12"
-content-hash = "c33378496709848054a8e4ecd1ebf74df12f15a1bb66ab61d2958e6a3c40f812"
+python-versions = "^3.10"
+content-hash = "e01f649e4ed95bc01a4a72a3ea90dc13a83e6e21d6e77d84b7adcdb2ca68dec8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ homepage = "https://ae.utbm.fr/"
 license = "GPL-3.0-only"
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.12" # Version is held back by mistune
+python = "^3.10"
 Django = "^4.2.13"
 Pillow = "^10.4.0"
-mistune = "^0.8.4"
+mistune = "^3.0.2"
 django-jinja = "^2.11"
 cryptography = "^42.0.8"
 pytz = "^2021.1"


### PR DESCRIPTION
Mise à jour de mistune vers sa version 3.

Ca permet en passant de retirer le `Python <3.12` dans le pyproject.toml.

J'en ai aussi profité pour refaire un peu le style du rendu markdown, notamment en ce qui concerne les bouts de code et les blocs de citation.

On passe de ça :
![image](https://github.com/ae-utbm/sith3/assets/56346771/c5b8ef2a-8096-47de-a950-3a5c631dae39)

A ça :
![image](https://github.com/ae-utbm/sith3/assets/56346771/b14bb456-18a3-4ebe-8507-6e31dc3bb57a)

Le code inline change aussi : 
![image](https://github.com/ae-utbm/sith3/assets/56346771/d15df604-938d-4104-8ee6-8adf252fe491)

la line-height des paragraphes, des ul et des ol a été légèrement augmentée.
Le code utilise la police Consolas (la police de Notepad, tmtc).

Les blocs de code et les blocs de citation sont un peu indentés, sauf sur petits écrans, où l'indentation est retirée.

Les tableaux ne prennent plus la totalité de l'espace (ce qui donnait des tableaux étrangement larges), mais seulement ce dont ils ont besoin.
![image](https://github.com/ae-utbm/sith3/assets/56346771/fe25f673-2500-475d-9810-30a1234dca17)

J'ai rajouté du padding au-dessus des titres :
![image](https://github.com/ae-utbm/sith3/assets/56346771/e41e8bfb-b333-478b-8336-ec3b9fd590bd)


J'ai retiré la barre de progression, qui n'avait pas d'exemple et que j'ai pas réussi à faire marcher avec l'ancien code.