### PR TITLE
Harmonize test names

### DIFF
--- a/accounting/tests.py
+++ b/accounting/tests.py
@@ -28,7 +28,7 @@ from accounting.models import (
 from core.models import User
 
 
-class RefoundAccountTest(TestCase):
+class TestRefoundAccount(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.skia = User.objects.get(username="skia")
@@ -67,7 +67,7 @@ class RefoundAccountTest(TestCase):
         assert self.skia.customer.amount == 0
 
 
-class JournalTest(TestCase):
+class TestJournal(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.journal = GeneralJournal.objects.get(id=1)
@@ -91,7 +91,7 @@ class JournalTest(TestCase):
         assert "<td>M\xc3\xa9thode de paiement</td>" not in str(response_get.content)
 
 
-class OperationTest(TestCase):
+class TestOperation(TestCase):
     def setUp(self):
         self.tomorrow_formatted = (date.today() + timedelta(days=1)).strftime(
             "%d/%m/%Y"

--- a/club/tests.py
+++ b/club/tests.py
@@ -28,7 +28,7 @@ from core.models import AnonymousUser, User
 from sith.settings import SITH_BAR_MANAGER, SITH_MAIN_CLUB_ID
 
 
-class ClubTest(TestCase):
+class TestClub(TestCase):
     """Set up data for test cases related to clubs and membership.
 
     The generated dataset is the one created by the populate command,
@@ -92,7 +92,7 @@ class ClubTest(TestCase):
         cache.clear()
 
 
-class MembershipQuerySetTest(ClubTest):
+class TestMembershipQuerySet(TestClub):
     def test_ongoing(self):
         """Test that the ongoing queryset method returns the memberships that
         are not ended.
@@ -170,7 +170,7 @@ class MembershipQuerySetTest(ClubTest):
             assert cached_mem == "not_member"
 
 
-class ClubModelTest(ClubTest):
+class TestClubModel(TestClub):
     def assert_membership_started_today(self, user: User, role: int):
         """Assert that the given membership is active and started today."""
         membership = user.memberships.ongoing().filter(club=self.club).first()
@@ -506,7 +506,7 @@ class ClubModelTest(ClubTest):
         assert self.club.is_owned_by(self.sli)
 
 
-class MailingFormTest(TestCase):
+class TestMailingForm(TestCase):
     """Perform validation tests for MailingForm."""
 
     @classmethod
@@ -822,7 +822,7 @@ class MailingFormTest(TestCase):
         assert "krophil@git.an" not in content
 
 
-class ClubSellingViewTest(TestCase):
+class TestClubSellingView(TestCase):
     """Perform basics tests to ensure that the page is available."""
 
     @classmethod

--- a/com/tests.py
+++ b/com/tests.py
@@ -45,7 +45,7 @@ def test_com_page_is_working(client, url, user_community):
     assert response.status_code == 200
 
 
-class ComTest(TestCase):
+class TestCom(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.skia = User.objects.get(username="skia")
@@ -113,7 +113,7 @@ class ComTest(TestCase):
         )
 
 
-class SithTest(TestCase):
+class TestSith(TestCase):
     def test_sith_owner(self):
         """Test that the sith instance is owned by com admins and nobody else."""
         sith: Sith = Sith.objects.first()
@@ -128,7 +128,7 @@ class SithTest(TestCase):
         assert not sith.is_owned_by(sli)
 
 
-class NewsTest(TestCase):
+class TestNews(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.com_admin = User.objects.get(username="comunity")
@@ -178,7 +178,7 @@ class NewsTest(TestCase):
         assert not self.new.can_be_edited_by(self.author)
 
 
-class WeekmailArticleTest(TestCase):
+class TestWeekmailArticle(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.com_admin = User.objects.get(username="comunity")
@@ -202,7 +202,7 @@ class WeekmailArticleTest(TestCase):
         assert not self.article.is_owned_by(self.sli)
 
 
-class PosterTest(TestCase):
+class TestPoster(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.com_admin = User.objects.get(username="comunity")

--- a/counter/tests.py
+++ b/counter/tests.py
@@ -27,7 +27,7 @@ from counter.models import BillingInfo, Counter, Customer, Permanency, Product, 
 from sith.settings import SITH_MAIN_CLUB
 
 
-class CounterTest(TestCase):
+class TestCounter(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.skia = User.objects.filter(username="skia").first()
@@ -150,7 +150,7 @@ class CounterTest(TestCase):
                 assert not counter.has_annotated_barman
 
 
-class CounterStatsTest(TestCase):
+class TestCounterStats(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.counter = Counter.objects.get(id=2)
@@ -300,7 +300,7 @@ class CounterStatsTest(TestCase):
         ]
 
 
-class BillingInfoTest(TestCase):
+class TestBillingInfo(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.payload_1 = {
@@ -528,7 +528,7 @@ class BillingInfoTest(TestCase):
         assert infos.country == "FR"
 
 
-class BarmanConnectionTest(TestCase):
+class TestBarmanConnection(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.krophil = User.objects.get(username="krophil")
@@ -578,7 +578,7 @@ class BarmanConnectionTest(TestCase):
         assert not '<li><a href="/user/1/">S&#39; Kia</a></li>' in str(response.content)
 
 
-class StudentCardTest(TestCase):
+class TestStudentCard(TestCase):
     """Tests for adding and deleting Stundent Cards
     Test that an user can be found with it's student card.
     """
@@ -883,7 +883,7 @@ class StudentCardTest(TestCase):
         assert response.status_code == 403
 
 
-class CustomerAccountIdTest(TestCase):
+class TestCustomerAccountId(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user_a = User.objects.create(

--- a/eboutic/tests.py
+++ b/eboutic/tests.py
@@ -39,7 +39,7 @@ from counter.models import Counter, Customer, Product, Selling
 from eboutic.models import Basket
 
 
-class EbouticTest(TestCase):
+class TestEboutic(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.barbar = Product.objects.get(code="BARB")

--- a/election/tests.py
+++ b/election/tests.py
@@ -6,7 +6,7 @@ from core.models import Group, User
 from election.models import Election
 
 
-class ElectionTest(TestCase):
+class TestElection(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.election = Election.objects.first()
@@ -18,7 +18,7 @@ class ElectionTest(TestCase):
         cls.public = User.objects.get(username="public")
 
 
-class ElectionDetailTest(ElectionTest):
+class TestElectionDetail(TestElection):
     def test_permission_denied(self):
         self.election.view_groups.remove(self.public_group)
         self.client.force_login(self.public)
@@ -36,7 +36,7 @@ class ElectionDetailTest(ElectionTest):
         assert "La roue tourne" in str(response.content)
 
 
-class ElectionUpdateView(ElectionTest):
+class TestElectionUpdateView(TestElection):
     def test_permission_denied(self):
         self.client.force_login(self.subscriber)
         response = self.client.get(

--- a/galaxy/tests.py
+++ b/galaxy/tests.py
@@ -33,7 +33,7 @@ from core.models import User
 from galaxy.models import Galaxy
 
 
-class GalaxyTestModel(TestCase):
+class TestGalaxyModel(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.root = User.objects.get(username="root")
@@ -144,7 +144,7 @@ class GalaxyTestModel(TestCase):
 
 
 @pytest.mark.slow
-class GalaxyTestView(TestCase):
+class TestGalaxyView(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Generate a plausible Galaxy once for every test."""

--- a/pedagogy/tests/test_api.py
+++ b/pedagogy/tests/test_api.py
@@ -11,7 +11,7 @@ from core.models import RealGroup, User
 from pedagogy.models import UV
 
 
-class UVSearchTest(TestCase):
+class TestUVSearch(TestCase):
     """Test UV guide rights for view and API."""
 
     @classmethod

--- a/pedagogy/tests/tests.py
+++ b/pedagogy/tests/tests.py
@@ -76,7 +76,7 @@ def create_uv_template(user_id, code="IFC1", exclude_list=None):
 # UV class tests
 
 
-class UVCreation(TestCase):
+class TestUVCreation(TestCase):
     """Test uv creation."""
 
     @classmethod
@@ -164,7 +164,7 @@ def test_guide_anonymous_permission_denied(client: Client):
     assert res.status_code == 302
 
 
-class UVDeleteTest(TestCase):
+class TestUVDelete(TestCase):
     """Test UV deletion rights."""
 
     @classmethod
@@ -205,7 +205,7 @@ class UVDeleteTest(TestCase):
         assert UV.objects.filter(pk=self.uv.pk).exists()
 
 
-class UVUpdateTest(TestCase):
+class TestUVUpdate(TestCase):
     """Test UV update rights."""
 
     @classmethod
@@ -291,7 +291,7 @@ def create_uv_comment_template(user_id, uv_code="PA00", exclude_list=None):
     return comment
 
 
-class UVCommentCreationAndDisplay(TestCase):
+class TestUVCommentCreationAndDisplay(TestCase):
     """Test UVComment creation and its display.
 
     Display and creation are the same view.
@@ -397,7 +397,7 @@ class UVCommentCreationAndDisplay(TestCase):
         assert response.status_code == 200
 
 
-class UVCommentDeleteTest(TestCase):
+class TestUVCommentDelete(TestCase):
     """Test UVComment deletion rights."""
 
     @classmethod
@@ -463,7 +463,7 @@ class UVCommentDeleteTest(TestCase):
         assert UVComment.objects.filter(id=self.comment.id).exists()
 
 
-class UVCommentUpdateTest(TestCase):
+class TestUVCommentUpdate(TestCase):
     """Test UVComment update rights."""
 
     @classmethod
@@ -554,7 +554,7 @@ class UVCommentUpdateTest(TestCase):
         self.assertEqual(self.comment.author, self.krophil)
 
 
-class UVModerationFormTest(TestCase):
+class TestUVModerationForm(TestCase):
     """Assert access rights and if the form works well."""
 
     @classmethod
@@ -767,7 +767,7 @@ class UVModerationFormTest(TestCase):
         assert UVComment.objects.filter(id=self.comment_2.id).exists()
 
 
-class UVCommentReportCreateTest(TestCase):
+class TestUVCommentReportCreate(TestCase):
     """Test report creation view.
 
     Assert access rights and if you can create with it.

--- a/rootplace/tests.py
+++ b/rootplace/tests.py
@@ -24,7 +24,7 @@ from counter.models import Counter, Customer, Product, Refilling, Selling
 from subscription.models import Subscription
 
 
-class MergeUserTest(TestCase):
+class TestMergeUser(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.ae = Club.objects.get(unix_name="ae")

--- a/sas/tests/test_api.py
+++ b/sas/tests/test_api.py
@@ -8,7 +8,7 @@ from core.models import User
 from sas.models import Album, PeoplePictureRelation, Picture
 
 
-class SasTest(TestCase):
+class TestSas(TestCase):
     @classmethod
     def setUpTestData(cls):
         Picture.objects.all().delete()

--- a/subscription/tests.py
+++ b/subscription/tests.py
@@ -79,7 +79,7 @@ def test_subscription_compute_end(start_date, duration, expected_end):
     assert Subscription.compute_end(duration, start_date) == expected_end
 
 
-class SubscriptionIntegrationTest(TestCase):
+class TestSubscriptionIntegration(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = User.objects.get(username="public")


### PR DESCRIPTION
Pytest n'aime pas les classes de test qui ne commencent pas par Test et ne les détecte pas sauf si ils héritent de TestCase.

Pour éviter les inconsistances et les erreurs futurs, j'harmonise tous les noms de class de test.