### PR TITLE
fix album order for user pictures

### DIFF
--- a/core/templates/core/user_pictures.jinja
+++ b/core/templates/core/user_pictures.jinja
@@ -22,17 +22,17 @@
     {% if can_edit(profile, user) %}
       <button disabled id="download" onclick="download('{{ url('api:pictures') }}?users_identified={{ object.id }}')">{% trans %}Download all my pictures{% endtrans %}</button>
     {% endif %}
-    {% for a in albums %}
-      <h4>{{ a.name }}</h4>
+    {% for album, album_pictures in pictures|groupby("album") %}
+      <h4>{{ album }}</h4>
       <div class="photos">
-        {% for p in pictures[a.id] %}
-          {% if p.can_be_viewed_by(user) %}
-            <a href="{{ url("sas:picture", picture_id=p.id) }}#pict">
+        {% for picture in album_pictures %}
+          {% if picture.can_be_viewed_by(user) %}
+            <a href="{{ url("sas:picture", picture_id=picture.id) }}#pict">
               <div
-                class="photo{% if not p.is_moderated %} not_moderated{% endif %}"
-                style="background-image: url('{% if p.file %}{{ p.get_download_thumb_url() }}{% else %}{{ static('core/img/sas.jpg') }}{% endif %}');"
+                class="photo{% if not picture.is_moderated %} not_moderated{% endif %}"
+                style="background-image: url('{% if picture.file %}{{ picture.get_download_thumb_url() }}{% else %}{{ static('core/img/sas.jpg') }}{% endif %}');"
               >
-                {% if not p.is_moderated %}
+                {% if not picture.is_moderated %}
                   <div class="overlay">&nbsp;</div>
                   <div class="text">{% trans %}To be moderated{% endtrans %}</div>
                 {% else %}

--- a/core/templates/core/user_pictures.jinja
+++ b/core/templates/core/user_pictures.jinja
@@ -22,10 +22,10 @@
     {% if can_edit(profile, user) %}
       <button disabled id="download" onclick="download('{{ url('api:pictures') }}?users_identified={{ object.id }}')">{% trans %}Download all my pictures{% endtrans %}</button>
     {% endif %}
-    {% for album, album_pictures in pictures|groupby("album") %}
+    {% for album, pictures in albums|items %}
       <h4>{{ album }}</h4>
       <div class="photos">
-        {% for picture in album_pictures %}
+        {% for picture in pictures %}
           {% if picture.can_be_viewed_by(user) %}
             <a href="{{ url("sas:picture", picture_id=picture.id) }}#pict">
               <div

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -314,7 +314,7 @@ class UserPicturesView(UserTabsMixin, CanViewMixin, DetailView):
         kwargs = super().get_context_data(**kwargs)
         kwargs["pictures"] = list(
             Picture.objects.filter(people__user_id=self.object.id)
-            .order_by("-parent__date", "id")
+            .order_by("-parent__date", "-date")
             .annotate(album=F("parent__name"))
         )
         return kwargs

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -21,6 +21,7 @@
 # Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 #
+import itertools
 
 # This file contains all the views that concern the user model
 from datetime import date, timedelta
@@ -312,11 +313,15 @@ class UserPicturesView(UserTabsMixin, CanViewMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         kwargs = super().get_context_data(**kwargs)
-        kwargs["pictures"] = list(
+        pictures = list(
             Picture.objects.filter(people__user_id=self.object.id)
             .order_by("-parent__date", "-date")
             .annotate(album=F("parent__name"))
         )
+        kwargs["albums"] = {
+            album: list(picts)
+            for album, picts in itertools.groupby(pictures, lambda i: i.album)
+        }
         return kwargs
 
 


### PR DESCRIPTION
Yom a fait remarquer que l'ordre dans lequel les photos sont affichées sur le profil utilisateur est inversée (c'est arrivé, précisément dans ce commit : 3046438cb1de9bd79bb042843391aa6c3486a5c6. C'est ma faute, déso).

La PR répare (avec au passage un tout petit refactor sur la manière de grouper les photos par album)