### PR TITLE
Accel redirect

### DIFF
--- a/core/lookups.py
+++ b/core/lookups.py
@@ -21,12 +21,12 @@ from club.models import Club
 from core.models import Group, SithFile, User
 from core.views.site import search_user
 from counter.models import Counter, Customer, Product
-from counter.utils import sent_from_logged_counter
+from counter.utils import is_logged_in_counter
 
 
 class RightManagedLookupChannel(LookupChannel):
     def check_auth(self, request):
-        if not request.user.was_subscribed and not sent_from_logged_counter(request):
+        if not request.user.was_subscribed and not is_logged_in_counter(request):
             raise PermissionDenied
 
 

--- a/core/lookups.py
+++ b/core/lookups.py
@@ -21,19 +21,12 @@ from club.models import Club
 from core.models import Group, SithFile, User
 from core.views.site import search_user
 from counter.models import Counter, Customer, Product
-
-
-def check_token(request):
-    return (
-        "counter_token" in request.session.keys()
-        and request.session["counter_token"]
-        and Counter.objects.filter(token=request.session["counter_token"]).exists()
-    )
+from counter.utils import sent_from_logged_counter
 
 
 class RightManagedLookupChannel(LookupChannel):
     def check_auth(self, request):
-        if not request.user.was_subscribed and not check_token(request):
+        if not request.user.was_subscribed and not sent_from_logged_counter(request):
             raise PermissionDenied
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -1137,11 +1137,9 @@ class SithFile(models.Model):
         else:
             self._check_path_consistence()
 
-    def __getattribute__(self, attr):
-        if attr == "is_file":
-            return not self.is_folder
-        else:
-            return super().__getattribute__(attr)
+    @property
+    def is_file(self):
+        return not self.is_folder
 
     @cached_property
     def as_picture(self):

--- a/core/views/files.py
+++ b/core/views/files.py
@@ -12,7 +12,7 @@
 # OR WITHIN THE LOCAL FILE "LICENSE"
 #
 #
-from urllib.parse import quote
+from urllib.parse import quote, urljoin
 
 # This file contains all the views that concern the page model
 from wsgiref.util import FileWrapper
@@ -38,7 +38,7 @@ from core.views import (
     CanViewMixin,
     can_view,
 )
-from counter.utils import sent_from_logged_counter
+from counter.utils import is_logged_in_counter
 
 
 def send_file(
@@ -55,7 +55,7 @@ def send_file(
     In debug mode, the server will directly send the file.
     """
     f = get_object_or_404(file_class, id=file_id)
-    if not can_view(f, request.user) and not sent_from_logged_counter(request):
+    if not can_view(f, request.user) and not is_logged_in_counter(request):
         raise PermissionDenied
     name = getattr(f, file_attr).name
     filepath = settings.MEDIA_ROOT / name
@@ -71,7 +71,7 @@ def send_file(
         # so please do not mess with this.
         response = HttpResponse(status=200)
         response["Content-Type"] = ""
-        response["X-Accel-Redirect"] = f"/data/{quote(name)}"
+        response["X-Accel-Redirect"] = quote(urljoin(settings.MEDIA_URL, name))
         return response
 
     with open(filepath, "rb") as filename:

--- a/counter/utils.py
+++ b/counter/utils.py
@@ -1,0 +1,36 @@
+from urllib.parse import urlparse
+
+from django.http import HttpRequest
+from django.urls import resolve
+
+from counter.models import Counter
+
+
+def sent_from_logged_counter(request: HttpRequest) -> bool:
+    """Check if the request is sent from a device logged to a counter.
+
+    The request must also be sent within the frame of a counter's activity.
+    Trying to use this function to manage access to non-sas
+    related resources probably won't work.
+
+    A request is considered as coming from a logged counter if :
+
+    - Its referer comes from the counter app
+      (eg. fetching user pictures from the click UI)
+      or the request path belongs to the counter app
+      (eg. the barman went back to the main by missclick and go back
+      to the counter)
+    - The current session has a counter token associated with it.
+    - A counter with this token exists.
+    """
+    referer = urlparse(request.META["HTTP_REFERER"]).path
+    path_ok = (
+        request.resolver_match.app_name == "counter"
+        or resolve(referer).app_name == "counter"
+    )
+    return (
+        path_ok
+        and "counter_token" in request.session
+        and request.session["counter_token"]
+        and Counter.objects.filter(token=request.session["counter_token"]).exists()
+    )

--- a/counter/utils.py
+++ b/counter/utils.py
@@ -6,7 +6,7 @@ from django.urls import resolve
 from counter.models import Counter
 
 
-def sent_from_logged_counter(request: HttpRequest) -> bool:
+def is_logged_in_counter(request: HttpRequest) -> bool:
     """Check if the request is sent from a device logged to a counter.
 
     The request must also be sent within the frame of a counter's activity.

--- a/counter/views.py
+++ b/counter/views.py
@@ -80,7 +80,7 @@ from counter.models import (
     Selling,
     StudentCard,
 )
-from counter.utils import sent_from_logged_counter
+from counter.utils import is_logged_in_counter
 
 
 class CounterAdminMixin(View):
@@ -904,7 +904,7 @@ class RefillingDeleteView(DeleteView):
         self.object = self.get_object()
         if timezone.now() - self.object.date <= timedelta(
             minutes=settings.SITH_LAST_OPERATIONS_LIMIT
-        ) and sent_from_logged_counter(request):
+        ) and is_logged_in_counter(request):
             self.success_url = reverse(
                 "counter:details", kwargs={"counter_id": self.object.counter.id}
             )
@@ -929,7 +929,7 @@ class SellingDeleteView(DeleteView):
         self.object = self.get_object()
         if timezone.now() - self.object.date <= timedelta(
             minutes=settings.SITH_LAST_OPERATIONS_LIMIT
-        ) and sent_from_logged_counter(request):
+        ) and is_logged_in_counter(request):
             self.success_url = reverse(
                 "counter:details", kwargs={"counter_id": self.object.counter.id}
             )
@@ -1164,7 +1164,7 @@ class CounterLastOperationsView(CounterTabsMixin, CanViewMixin, DetailView):
     def dispatch(self, request, *args, **kwargs):
         """We have here again a very particular right handling."""
         self.object = self.get_object()
-        if sent_from_logged_counter(request) and self.object.barmen_list:
+        if is_logged_in_counter(request) and self.object.barmen_list:
             return super().dispatch(request, *args, **kwargs)
         return HttpResponseRedirect(
             reverse("counter:details", kwargs={"counter_id": self.object.id})
@@ -1197,7 +1197,7 @@ class CounterCashSummaryView(CounterTabsMixin, CanViewMixin, DetailView):
     def dispatch(self, request, *args, **kwargs):
         """We have here again a very particular right handling."""
         self.object = self.get_object()
-        if sent_from_logged_counter(request) and self.object.barmen_list:
+        if is_logged_in_counter(request) and self.object.barmen_list:
             return super().dispatch(request, *args, **kwargs)
         return HttpResponseRedirect(
             reverse("counter:details", kwargs={"counter_id": self.object.id})

--- a/counter/views.py
+++ b/counter/views.py
@@ -80,6 +80,7 @@ from counter.models import (
     Selling,
     StudentCard,
 )
+from counter.utils import sent_from_logged_counter
 
 
 class CounterAdminMixin(View):
@@ -901,15 +902,9 @@ class RefillingDeleteView(DeleteView):
     def dispatch(self, request, *args, **kwargs):
         """We have here a very particular right handling, we can't inherit from CanEditPropMixin."""
         self.object = self.get_object()
-        if (
-            timezone.now() - self.object.date
-            <= timedelta(minutes=settings.SITH_LAST_OPERATIONS_LIMIT)
-            and "counter_token" in request.session.keys()
-            and request.session["counter_token"]
-            and Counter.objects.filter(  # check if not null for counters that have no token set
-                token=request.session["counter_token"]
-            ).exists()
-        ):
+        if timezone.now() - self.object.date <= timedelta(
+            minutes=settings.SITH_LAST_OPERATIONS_LIMIT
+        ) and sent_from_logged_counter(request):
             self.success_url = reverse(
                 "counter:details", kwargs={"counter_id": self.object.counter.id}
             )
@@ -932,15 +927,9 @@ class SellingDeleteView(DeleteView):
     def dispatch(self, request, *args, **kwargs):
         """We have here a very particular right handling, we can't inherit from CanEditPropMixin."""
         self.object = self.get_object()
-        if (
-            timezone.now() - self.object.date
-            <= timedelta(minutes=settings.SITH_LAST_OPERATIONS_LIMIT)
-            and "counter_token" in request.session.keys()
-            and request.session["counter_token"]
-            and Counter.objects.filter(  # check if not null for counters that have no token set
-                token=request.session["counter_token"]
-            ).exists()
-        ):
+        if timezone.now() - self.object.date <= timedelta(
+            minutes=settings.SITH_LAST_OPERATIONS_LIMIT
+        ) and sent_from_logged_counter(request):
             self.success_url = reverse(
                 "counter:details", kwargs={"counter_id": self.object.counter.id}
             )
@@ -1175,14 +1164,7 @@ class CounterLastOperationsView(CounterTabsMixin, CanViewMixin, DetailView):
     def dispatch(self, request, *args, **kwargs):
         """We have here again a very particular right handling."""
         self.object = self.get_object()
-        if (
-            self.object.barmen_list
-            and "counter_token" in request.session.keys()
-            and request.session["counter_token"]
-            and Counter.objects.filter(  # check if not null for counters that have no token set
-                token=request.session["counter_token"]
-            ).exists()
-        ):
+        if sent_from_logged_counter(request) and self.object.barmen_list:
             return super().dispatch(request, *args, **kwargs)
         return HttpResponseRedirect(
             reverse("counter:details", kwargs={"counter_id": self.object.id})
@@ -1215,14 +1197,7 @@ class CounterCashSummaryView(CounterTabsMixin, CanViewMixin, DetailView):
     def dispatch(self, request, *args, **kwargs):
         """We have here again a very particular right handling."""
         self.object = self.get_object()
-        if (
-            self.object.barmen_list
-            and "counter_token" in request.session.keys()
-            and request.session["counter_token"]
-            and Counter.objects.filter(  # check if not null for counters that have no token set
-                token=request.session["counter_token"]
-            ).exists()
-        ):
+        if sent_from_logged_counter(request) and self.object.barmen_list:
             return super().dispatch(request, *args, **kwargs)
         return HttpResponseRedirect(
             reverse("counter:details", kwargs={"counter_id": self.object.id})

--- a/docs/tutorial/install-advanced.md
+++ b/docs/tutorial/install-advanced.md
@@ -9,6 +9,33 @@ que votre environnement de développement soit encore plus
 proche de celui en production.
 Voici les étapes à suivre pour ça.
 
+!!!tip
+
+    Configurer les dépendances du projet
+    peut demander beaucoup d'allers et retours entre
+    votre répertoire projet et divers autres emplacements.
+
+    Vous pouvez gagner du temps en déclarant un alias :
+
+    === "bash/zsh"
+
+        ```bash
+        alias cdp="cd /repertoire/du/projet"
+        ```
+
+    === "nu"
+
+        ```nu
+        alias cdp = cd /repertoire/du/projet
+        ```
+
+    Chaque fois qu'on vous demandera de retourner au répertoire
+    projet, vous aurez juste à faire :
+
+    ```bash
+    cdp
+    ```
+
 ## Installer les dépendances manquantes
 
 Pour installer complètement le projet, il va falloir
@@ -20,19 +47,19 @@ Commencez par installer les dépendances système :
     === "Debian/Ubuntu"
 
         ```bash
-        sudo apt install postgresql redis libq-dev
+        sudo apt install postgresql redis libq-dev nginx
         ```
 
     === "Arch Linux"
     
         ```bash
-        sudo pacman -S postgresql redis
+        sudo pacman -S postgresql redis nginx
         ```
 
 === "macOS"
 
     ```bash
-    brew install postgresql redis nginx lipbq
+    brew install postgresql redis lipbq nginx
     export PATH="/usr/local/opt/libpq/bin:$PATH"
     source ~/.zshrc
     ```
@@ -138,6 +165,102 @@ poetry run ./manage.py populate
 
     N'oubliez de quitter la session de l'utilisateur
     postgres après avoir configuré la db.
+
+## Configurer nginx
+
+Nginx est utilisé comme reverse-proxy.
+
+!!!warning
+
+    Nginx ne sert pas les fichiers de la même manière que Django.
+    Les fichiers statiques servis seront ceux du dossier `/static`,
+    tels que générés par les commandes `collectstatic` et
+    `compilestatic`.
+    Si vous changez du css ou du js sans faire tourner
+    ces commandes, ces changements ne seront pas reflétés.
+
+    De manière générale, utiliser nginx en dev n'est pas très utile,
+    voire est gênant si vous travaillez sur le front.
+    Ne vous embêtez pas avec ça, sauf par curiosité intellectuelle,
+    ou bien si vous voulez tester spécifiquement 
+    des interactions avec le reverse proxy.
+
+
+Placez-vous dans le répertoire `/etc/nginx`, 
+et créez les dossiers et fichiers nécessaires :
+
+```bash
+cd /etc/nginx/
+sudo mkdir sites-enabled sites-available
+sudo touch sites-available/sith.conf
+sudo ln -s /etc/nginx/sites-available/sith.conf sites-enabled/sith.conf
+```
+
+Puis ouvrez le fichier `sites-available/sith.conf` et mettez-y le contenu suivant :
+
+```nginx
+server {
+    listen 8000;
+
+    server_name _;
+
+    location /static/;
+        root /repertoire/du/projet;
+    }
+    location ~ ^/data/(products|com|club_logos)/ {
+        root /repertoire/du/projet;
+    }
+    location ~ ^/data/(SAS|profiles|users|.compressed|.thumbnails)/ {
+        # https://nginx.org/en/docs/http/ngx_http_core_module.html#internal
+        internal;
+        root /repertoire/du/projet;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8001;
+        include uwsgi_params;
+    }
+}
+```
+
+Ouvrez le fichier `nginx.conf`, et ajoutez la configuration suivante :
+
+```nginx
+http {
+    # Toute la configuration
+    # éventuellement déjà là
+
+    include /etc/nginx/sites-enabled/sith.conf;
+}
+```
+
+Vérifiez que votre configuration est bonne :
+
+```bash
+sudo nginx -t
+```
+
+Si votre configuration n'est pas bonne, corrigez-la.
+Puis lancez ou relancez nginx :
+
+```bash
+sudo systemctl restart nginx
+```
+
+Dans votre `settings_custom.py`, remplacez `DEBUG=True` par `DEBUG=False`.
+
+Enfin, démarrez le serveur Django :
+
+```bash
+cd /repertoire/du/projet
+poetry run ./manage.py runserver 8001
+```
+
+Et c'est bon, votre reverse-proxy est prêt à tourner devant votre serveur.
+Nginx écoutera sur le port 8000.
+Toutes les requêtes vers des fichiers statiques et les medias publiques
+seront seront servies directement par nginx.
+Toutes les autres requêtes seront transmises au serveur django.
 
 
 ## Mettre à jour la base de données antispam


### PR DESCRIPTION
Les performances du SAS sont vraiment mauvaises, Même en ayant peu de photos, mon profil charge en 5 secondes. Sli, c'est plus de 20 secondes. Et pour Skia, on dépasse les 40 secondes.

Dans ce total, on a le chargement initial qui prend environ 1/4 de la durée (c'est déjà énorme, mais on s'occupera de ce problème dans une PR un peu plus tard), et la majeure partie du reste qui est occupée par l'envoi des images.

Et justement, ça pose problème, parce que notre serveur Python n'est pas vraiment fait pour servir des fichiers. Mieux vaut refiler ce travail à nginx. Pour ça, on joint à la réponse le header `X-Accel-Redirect`, et le reverse-proxy se charge du reste.

Ca suffira pas à rendre le chargement des pages du SAS instantané, mais ça devrait déjà l'accélerer (je saurais pas dire à quel point, par contre, c'est assez imprévisible avant qu'on le voit arriver en prod).

GROS WARNING : faudra changer la config nginx avant le déploiement, sinon ça va 404 toutes les images protégées. Même dans le pire des cas, ça ne devrait pas entrainer de grosse merde, type "écrasement de données", mais ça peut quand même casser le SAS, donc je préfère faire ce genre de chose pendant les vacances.

Une fois que ça sera fait, on pourra s'attaquer aux autres optimisations.