### PR TITLE
repair name of protected files

### DIFF
--- a/core/views/files.py
+++ b/core/views/files.py
@@ -58,30 +58,28 @@ def send_file(
     if not can_view(f, request.user) and not is_logged_in_counter(request):
         raise PermissionDenied
     name = getattr(f, file_attr).name
-    filepath = settings.MEDIA_ROOT / name
 
-    # check if file exists on disk
-    if not filepath.exists():
-        raise Http404
-
+    response = HttpResponse(
+        headers={"Content-Disposition": f'inline; filename="{quote(name)}"'}
+    )
     if not settings.DEBUG:
         # When receiving a response with the Accel-Redirect header,
         # the reverse proxy will automatically handle the file sending.
         # This is really hard to test (thus isn't tested)
         # so please do not mess with this.
-        response = HttpResponse(status=200)
-        response["Content-Type"] = ""
+        response["Content-Type"] = ""  # automatically set by nginx
         response["X-Accel-Redirect"] = quote(urljoin(settings.MEDIA_URL, name))
         return response
 
+    filepath = settings.MEDIA_ROOT / name
+    # check if file exists on disk
+    if not filepath.exists():
+        raise Http404
     with open(filepath, "rb") as filename:
-        wrapper = FileWrapper(filename)
-        response = HttpResponse(wrapper, content_type=f.mime_type)
+        response.content = FileWrapper(filename)
+        response["Content-Type"] = f.mime_type
         response["Last-Modified"] = http_date(f.date.timestamp())
         response["Content-Length"] = filepath.stat().st_size
-        response["Content-Disposition"] = ('inline; filename="%s"' % f.name).encode(
-            "utf-8"
-        )
         return response
 
 


### PR DESCRIPTION
Depuis l'implémentation de l'envoi des fichiers par le reverse-proxy, le nom des fichiers n'était plus envoyé.
En fait, j'avais oublié le header "Content-disposition".