### PR TITLE
fix image extension

### DIFF
--- a/sas/models.py
+++ b/sas/models.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from io import BytesIO
+from pathlib import Path
 from typing import ClassVar, Self
 
 from django.conf import settings
@@ -123,7 +124,7 @@ class Picture(SasFile):
             self.file.delete()
             self.thumbnail.delete()
             self.compressed.delete()
-        new_extension_name = self.name.removesuffix(extension) + "webp"
+        new_extension_name = str(Path(self.name).with_suffix(".webp"))
         self.file = file
         self.file.name = self.name
         self.thumbnail = thumb


### PR DESCRIPTION
Quand une image en .jpg est uploadé, le changement d'extension en webp marche pas bien. Au lieu de se retrouver avec des .webp, on se retrouve avec des .jpgwebp.