### PR TITLE
Repair populate more

### DIFF
--- a/core/management/commands/populate_more.py
+++ b/core/management/commands/populate_more.py
@@ -288,7 +288,7 @@ class Command(BaseCommand):
                 since=Subquery(
                     Subscription.objects.filter(member__customer=OuterRef("pk"))
                     .annotate(res=Min("subscription_start"))
-                    .values("res")
+                    .values("res")[:1]
                 )
             )
         )


### PR DESCRIPTION
La requête des sélection des clients dans la fonction de création des ventes avait une erreur qui faisait planter la commande (plus précisément, une sous-requête renvoyait plus qu'un seul élément).

Ca faisait planter sur postgres.