### PR TITLE
fix: `fetch_paginated`

### DIFF
--- a/core/static/core/js/script.js
+++ b/core/static/core/js/script.js
@@ -108,7 +108,8 @@ function update_query_string(key, value, action = History.REPLACE, url = null) {
     return url;
 }
 
-
+// TODO : If one day a test workflow is made for JS in this project
+//  please test this function. A all cost.
 /**
  * Given a paginated endpoint, fetch all the items of this endpoint,
  * performing multiple API calls if necessary.
@@ -135,7 +136,7 @@ async function fetch_paginated(url) {
           fetch(paginated_url).then(res => res.json().then(json => json.results))
         );
       }
-      results.push(...await Promise.all(promises))
+      results.push(...(await Promise.all(promises)).flat())
   }
   return results;
 }


### PR DESCRIPTION
La fonction `fetch_paginated` est cassée. quand on a besoin de faire des appels en plus, le `Promise.all()` retourne un tableau de tableaux. Ca fait que quand on fait `result.push(...await Promise.all(promises))`, au lieu de se retrouver avec `[a, b, c, d, e, f, g, h]`, on se retrouve avec `[a, b, c, [d, e, f], [g, h]]`.

Bref, on avait oublié le flatten.

En test, on a pas d'album avec plus de 200 photos, donc on l'avait juste pas vu.