### PR TITLE
Fixes after last deployment

### DIFF
--- a/core/static/user/js/family_graph.js
+++ b/core/static/user/js/family_graph.js
@@ -77,11 +77,11 @@ function create_graph(container, data, active_user_id) {
       fit: true,
       klay: {
         addUnnecessaryBendpoints: true,
-        direction: 'DOWN',
-        nodePlacement: 'INTERACTIVE',
-        layoutHierarchy: true
-      }
-    }
+        direction: "DOWN",
+        nodePlacement: "INTERACTIVE",
+        layoutHierarchy: true,
+      },
+    },
   });
   let active_user = cy
     .getElementById(active_user_id)
@@ -178,7 +178,9 @@ document.addEventListener("alpine:init", () => {
     typeof depth_min === "undefined" ||
     typeof depth_max === "undefined"
   ) {
-    console.error("Some constants are not set before using the family_graph script, please look at the documentation");
+    console.error(
+      "Some constants are not set before using the family_graph script, please look at the documentation",
+    );
     return;
   }
 
@@ -194,7 +196,7 @@ document.addEventListener("alpine:init", () => {
     loading: false,
     godfathers_depth: get_initial_depth("godfathers_depth"),
     godchildren_depth: get_initial_depth("godchildren_depth"),
-    reverse: initialUrlParams.get("reverse")?.toLowerCase?.() === 'true',
+    reverse: initialUrlParams.get("reverse")?.toLowerCase?.() === "true",
     graph: undefined,
     graph_data: {},
 
@@ -227,7 +229,11 @@ document.addEventListener("alpine:init", () => {
     async screenshot() {
       const link = document.createElement("a");
       link.href = this.graph.jpg();
-      link.download = gettext("family_tree.%(extension)s", "jpg");
+      link.download = interpolate(
+        gettext("family_tree.%(extension)s"),
+        { extension: "jpg" },
+        true,
+      );
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/sas/static/sas/js/viewer.js
+++ b/sas/static/sas/js/viewer.js
@@ -201,7 +201,7 @@ document.addEventListener("alpine:init", () => {
     },
 
     async delete_picture() {
-      const res = await fetch(`/api/sas/picture/${this.current_picture.id}/`, {
+      const res = await fetch(`/api/sas/picture/${this.current_picture.id}`, {
         method: "DELETE",
       });
       if (!res.ok) {


### PR DESCRIPTION
La suppression des images du SAS était cassée. Mais pour des raisons différentes de la dernière fois.

Deux leçons à tirer de ça :

1. Faut pas mettre de `/` à la fin des urls qui sont adressées à l'API
2. Quand npm a fini d'être installé, faut qu'on essaie de mettre en place des tests pour le front.

Les extensions des arbres généalogiques étaient cassées aussi.