### PR TITLE
Optimize SithFile recursive rights

### DIFF
--- a/core/tests/test_family.py
+++ b/core/tests/test_family.py
@@ -22,7 +22,7 @@ class TestFetchFamilyApi(TestCase):
         #           <- user5
 
         cls.main_user = baker.make(User)
-        cls.users = baker.make(User, _quantity=17)
+        cls.users = baker.make(User, _quantity=17, _bulk_create=True)
         cls.main_user.godfathers.add(*cls.users[0:3])
         cls.main_user.godchildren.add(*cls.users[3:6])
         cls.users[1].godfathers.add(cls.users[6])


### PR DESCRIPTION
Grosse optimisation de la manière dont les droits sont appliqués. Au lieu d'explorer l'arbre des descendants noeud par noeud, on le fait étage par étage, avec une seule requête par étage.

Au total, ça demande 1 requête par étage + 3 requêtes pour appliquer les nouveaux view_groups + 3 requêtes pour appliquer les nouveaux edit_groups, ce qui fait qu'on ne dépassera pratiquement jamais la vingtaine de requêtes, là où la méthode actuelle peut nécessiter plusieurs centaines, voire milliers, de requêtes.

C'est assez critique, dans la mesure où actuellement, quand on tente d'appliquer récursivement les droits sur certains albums du sas, ça timeout.