### PR TITLE
Fix 500 whean searching users

### DIFF
--- a/core/search_indexes.py
+++ b/core/search_indexes.py
@@ -33,6 +33,9 @@ class UserIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     auto = indexes.EdgeNgramField(use_template=True)
     last_update = indexes.DateTimeField(model_attr="last_update")
+    last_login = indexes.DateTimeField(
+        model_attr="last_login", default="1970-01-01T00:00:00Z"
+    )
 
     def get_model(self):
         return User

--- a/core/tests/test_user.py
+++ b/core/tests/test_user.py
@@ -37,6 +37,8 @@ class TestSearchUsers(TestCase):
         # restore the index
         call_command("update_index", "core", "--remove")
 
+
+class TestSearchUsersAPI(TestSearchUsers):
     def test_order(self):
         """Test that users are ordered by last login date."""
         self.client.force_login(subscriber_user.make())
@@ -83,3 +85,13 @@ class TestSearchUsers(TestCase):
         response = self.client.get(reverse("api:search_users") + "?search=bél")
         assert response.status_code == 200
         assert [r["id"] for r in response.json()["results"]] == [belix.id]
+
+
+class TestSearchUsersView(TestSearchUsers):
+    """Test the search user view (`GET /search`)."""
+
+    def test_page_ok(self):
+        """Just test that the page loads."""
+        self.client.force_login(subscriber_user.make())
+        response = self.client.get(reverse("core:search"))
+        assert response.status_code == 200

--- a/core/views/site.py
+++ b/core/views/site.py
@@ -85,7 +85,8 @@ def search_user(query):
             SearchQuerySet()
             .models(User)
             .autocomplete(auto=query)
-            .order_by("-last_login")[:20]
+            .order_by("-last_login")
+            .load_all()[:20]
         )
         return [r.object for r in res]
     except TypeError:


### PR DESCRIPTION
Après le changement de critère de tri des utilisateurs dans la recherche (`last_login` au lieu de `last_update`), la recherche des utilisateurs a cassé. J'avais oublié de rajouter le `last_login` en question dans le `UserIndex`.