### PR TITLE
fix profile pictures layout in Select2 results

### DIFF
--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -647,7 +647,9 @@ a:not(.button) {
     align-items: center;
 
     img {
-      max-height: 40px;
+      height: 40px;
+      width: 40px;
+      object-fit: cover;
       border-radius: 50%;
     }
   }


### PR DESCRIPTION
Les utilisateurs avec un aspect ratio très déséquilibré n'étaient pas bien rendus quand on les cherchait pour les identifier sur le SAS.